### PR TITLE
Use rsync --list-only instead of remote find for min_age_days

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -256,7 +256,7 @@ By default only repository code is backed up. Metadata options (issues, pulls, l
 - `ssh_port`: SSH port (default: `22`).
 - `delete_destination`: remove files at destination that no longer exist at source (default: `true`). When combined with `min_age_days`, the destination becomes an exact mirror of the filtered file set: any destination file that is **not** in the age-filtered list is removed. This means files newer than `min_age_days` will **not** be present at the destination. Set `delete_destination` to `false` if you want to accumulate old files while keeping previously synced files intact.
 - `exclude`: list of rsync exclude patterns (default: none).
-- `min_age_days`: only copy files whose modification time is older than this many days (default: none — copy all files). When set, CloudDump SSHs to the remote to discover qualifying files via `find -mtime`, then passes the list to rsync with `--files-from`. Requires GNU `find` on the remote; falls back to POSIX `find` + `sed` on BSD/macOS.
+- `min_age_days`: only copy files whose modification time is older than this many days (default: none — copy all files). When set, CloudDump enumerates remote files via `rsync --list-only`, filters by mtime client-side, and passes the qualifying paths to the main rsync with `--files-from`. Uses the rsync protocol only — no remote shell commands — so it works with restricted SSH accounts (forced commands, `rrsync`, etc.).
 
 The SSH key file should be mounted read-only into the container:
 

--- a/clouddump/job_rsync.py
+++ b/clouddump/job_rsync.py
@@ -2,7 +2,6 @@
 
 import os
 import re
-import shlex
 import subprocess
 import tempfile
 import time
@@ -13,9 +12,14 @@ from clouddump import cfg, log, run_cmd
 # user@host:/path — no shell metacharacters anywhere
 _SOURCE_RE = re.compile(r"^[a-zA-Z0-9._-]+@[a-zA-Z0-9._-]+:/[a-zA-Z0-9_./ -]+$")
 
+# rsync --list-only line: "<perms> <size> YYYY/MM/DD HH:MM:SS <path>"
+_LIST_LINE_RE = re.compile(
+    r"^(?P<perms>\S+)\s+\S+\s+(?P<date>\d{4}/\d{2}/\d{2})\s+(?P<time>\d{2}:\d{2}:\d{2})\s+(?P<name>.+)$"
+)
+
 
 def _build_ssh_args(ssh_key, ssh_port):
-    """Return the common SSH option list used by both find and rsync."""
+    """Return the common SSH option list used by rsync."""
     return [
         "ssh", "-i", ssh_key, "-p", ssh_port,
         "-o", "StrictHostKeyChecking=accept-new",
@@ -24,27 +28,37 @@ def _build_ssh_args(ssh_key, ssh_port):
 
 
 def _find_old_files(host_part, remote_path, min_age_days, ssh_args):
-    """SSH to remote and find files older than *min_age_days*.
+    """List remote files older than *min_age_days* via ``rsync --list-only``.
 
-    Returns a list of paths relative to *remote_path*, or ``None`` on failure.
+    Uses the rsync protocol itself to enumerate files — no remote shell
+    invocation, so it works with restricted accounts (forced commands,
+    rrsync, etc.). Returns paths relative to *remote_path*, or ``None``
+    on failure.
     """
-    # Ensure remote_path ends with / so the relative-path stripping works
     if not remote_path.endswith("/"):
         remote_path += "/"
-    safe_path = shlex.quote(remote_path)
-    # Try GNU find -printf first; fall back to POSIX find + sed for BSD/macOS
-    find_expr = (
-        f"find {safe_path} -type f -mtime +{min_age_days} -printf '%P\\n'"
-        f" 2>/dev/null || find {safe_path} -type f -mtime +{min_age_days}"
-        f" | sed 's|^{remote_path}||'"
-    )
-    cmd = ssh_args + [host_part, find_expr]
+    ssh_cmd = " ".join(ssh_args)
+    cmd = ["rsync", "-rn", "--list-only", "-e", ssh_cmd, f"{host_part}:{remote_path}"]
     proc = subprocess.run(cmd, capture_output=True, text=True)
     if proc.returncode != 0:
-        log.error("Remote find failed (rc %d): %s", proc.returncode, proc.stderr.strip())
+        log.error("Remote listing failed (rc %d): %s", proc.returncode, proc.stderr.strip())
         return None
-    lines = proc.stdout.strip().split("\n") if proc.stdout.strip() else []
-    return lines
+
+    cutoff = time.time() - (min_age_days * 86400)
+    files = []
+    for line in proc.stdout.splitlines():
+        m = _LIST_LINE_RE.match(line)
+        if not m or not m.group("perms").startswith("-"):
+            continue
+        try:
+            mtime = time.mktime(time.strptime(
+                f"{m.group('date')} {m.group('time')}", "%Y/%m/%d %H:%M:%S"
+            ))
+        except ValueError:
+            continue
+        if mtime < cutoff:
+            files.append(m.group("name"))
+    return files
 
 
 def run_rsync_sync(target, logfile_path):

--- a/tests/test_runners.py
+++ b/tests/test_runners.py
@@ -946,6 +946,66 @@ class TestRsyncRunner:
         assert "--delete" in cmd
 
 
+class TestFindOldFiles:
+    """Tests for _find_old_files — the rsync --list-only parser."""
+
+    @staticmethod
+    def _fake_proc(stdout="", returncode=0, stderr=""):
+        import types
+        return types.SimpleNamespace(stdout=stdout, stderr=stderr, returncode=returncode)
+
+    def _stub_run(self, monkeypatch, stdout, rc=0):
+        from clouddump import job_rsync
+        captured = {}
+
+        def fake_run(cmd, capture_output, text):
+            captured["cmd"] = cmd
+            return self._fake_proc(stdout=stdout, returncode=rc)
+
+        monkeypatch.setattr(job_rsync.subprocess, "run", fake_run)
+        return captured
+
+    def test_parses_list_and_filters_by_age(self, monkeypatch):
+        import time
+        from clouddump.job_rsync import _find_old_files
+
+        old_date = time.strftime("%Y/%m/%d", time.localtime(time.time() - 60 * 86400))
+        new_date = time.strftime("%Y/%m/%d", time.localtime(time.time() - 1 * 86400))
+        stdout = (
+            f"drwxr-xr-x          4,096 {new_date} 10:00:00 .\n"
+            f"-rw-r--r--           1234 {old_date} 10:00:00 old/file1.txt\n"
+            f"-rw-r--r--           5678 {new_date} 10:00:00 new/file2.txt\n"
+            f"-rw-r--r--            222 {old_date} 10:00:00 old/with space.log\n"
+        )
+        self._stub_run(monkeypatch, stdout)
+
+        files = _find_old_files("user@h", "/srv/x", 30, ["ssh"])
+        assert files == ["old/file1.txt", "old/with space.log"]
+
+    def test_returns_none_on_rsync_failure(self, monkeypatch):
+        from clouddump.job_rsync import _find_old_files
+
+        self._stub_run(monkeypatch, stdout="", rc=23)
+        assert _find_old_files("user@h", "/srv/x", 30, ["ssh"]) is None
+
+    def test_empty_list_returns_empty(self, monkeypatch):
+        from clouddump.job_rsync import _find_old_files
+
+        self._stub_run(monkeypatch, stdout="")
+        assert _find_old_files("user@h", "/srv/x", 30, ["ssh"]) == []
+
+    def test_uses_list_only_not_shell_find(self, monkeypatch):
+        from clouddump.job_rsync import _find_old_files
+
+        captured = self._stub_run(monkeypatch, stdout="")
+        _find_old_files("user@h", "/srv/x", 30, ["ssh", "-i", "key"])
+
+        assert captured["cmd"][0] == "rsync"
+        assert "--list-only" in captured["cmd"]
+        # No shell redirects or find commands
+        assert not any("find" in a or "2>" in a for a in captured["cmd"])
+
+
 # ── Job dispatch ────────────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary
- Replace SSH+`find` enumeration in `_find_old_files` with `rsync -rn --list-only`, then filter mtime client-side in Python.
- No more remote shell invocation — works with restricted SSH accounts (forced commands, `rrsync`, minimal wrappers).
- Added `TestFindOldFiles` unit tests covering list parsing, age filtering, failure propagation, and command shape.

## Why
Nightly `rsync-iot-webcam` job failed repeatedly with `find: paths must precede expression: '2>/dev/null'`. The remote shell on the target account didn't process the redirect, so `find` got it as a literal argument. The shell-command approach is inherently fragile on restricted SSH configurations; `rsync --list-only` uses only the rsync protocol.

## Test plan
- [x] `pytest tests/test_runners.py` — 76 passed
- [ ] After release & heimdall tag bump: verify `rsync-iot-webcam` job runs clean in heimdall journal

🤖 Generated with [Claude Code](https://claude.com/claude-code)