### PR TITLE
Connectivity fix: Suppress SSH host-key notice in WARN output

### DIFF
--- a/clouddump/config.py
+++ b/clouddump/config.py
@@ -254,12 +254,19 @@ def _run_verify(cmd, label, job_id, results, env=None, timeout=15):
         log.warning("%s timed out (job %s).", label, job_id)
         return None
 
+    # Separate benign SSH host-key acceptance notices from real errors.
+    stderr_lines, host_key_notices = [], []
+    for line in proc.stderr.strip().splitlines():
+        (host_key_notices if "Permanently added" in line else stderr_lines).append(line)
+    for notice in host_key_notices:
+        log.info("%s (job %s): %s", label, job_id, notice)
+
     if proc.returncode == 0:
         results.append(f"OK: {label} (job {job_id})")
         log.info("%s verified (job %s).", label, job_id)
         return proc
 
-    err = proc.stderr.strip().splitlines()[-1] if proc.stderr.strip() else "failed"
+    err = stderr_lines[-1] if stderr_lines else "failed"
     results.append(f"WARN: {label} — {err} (job {job_id})")
     log.warning("%s failed (job %s): %s", label, job_id, err)
     return None

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -601,6 +601,38 @@ def test_verify_rsync_ssh_failure(mock_run):
 
 
 @patch("subprocess.run")
+def test_verify_rsync_ssh_ok_ignores_host_key_notice(mock_run):
+    """First-boot SSH host-key acceptance notice must not produce a WARN."""
+    mock_run.return_value.returncode = 0
+    mock_run.return_value.stdout = ""
+    mock_run.return_value.stderr = (
+        "Warning: Permanently added '10.0.0.1' (ED25519) to the list of known hosts.\n"
+    )
+    job = _job(type="rsync", targets=[{
+        "source": "user@10.0.0.1:/data", "ssh_key": "/config/id_ed25519"}])
+    results = verify_connectivity([job])
+    assert any("OK" in r and "SSH" in r for r in results)
+    assert not any("WARN" in r for r in results)
+
+
+@patch("subprocess.run")
+def test_verify_rsync_ssh_failure_skips_host_key_notice(mock_run):
+    """Real errors must surface even when host-key notice is also in stderr."""
+    mock_run.return_value.returncode = 1
+    mock_run.return_value.stdout = ""
+    mock_run.return_value.stderr = (
+        "Warning: Permanently added '10.0.0.1' (ED25519) to the list of known hosts.\n"
+        "Permission denied (publickey).\n"
+    )
+    job = _job(type="rsync", targets=[{
+        "source": "user@10.0.0.1:/data", "ssh_key": "/config/id_ed25519"}])
+    results = verify_connectivity([job])
+    warn = next(r for r in results if "WARN" in r)
+    assert "Permission denied" in warn
+    assert "Permanently added" not in warn
+
+
+@patch("subprocess.run")
 def test_verify_pgsql_databases_and_tables(mock_run):
     """Configured databases + table filters verified in one flow."""
     # First call: list databases. Second call: list tables.


### PR DESCRIPTION
## Related
- Fixes spurious WARN reported on heimdall.rbt.no fresh boot for job ``rsync-iot-webcam``.

## Background
On first boot the connectivity report showed:

```
WARN: SSH 'clouddump-rsync@10.194.241.2:/srv/rbt-iot/webcam/' — Warning: Permanently added '10.194.241.2' (ED25519) to the list of known hosts. (job rsync-iot-webcam)
```

``StrictHostKeyChecking=accept-new`` prints that line to stderr the first time a host key is recorded. ``_run_verify`` picked the last stderr line as the failure reason, so the benign notice was reported as the WARN message.

## Changes
- ``_run_verify`` now separates ``Permanently added`` lines from the rest of stderr, logs them at INFO level (so the host record is still visible), and uses the remaining stderr lines for the WARN message.
- Two new tests:
  - Host-key notice on a successful check does not produce a WARN.
  - Real errors (e.g. ``Permission denied``) still surface and the host-key notice is filtered out of the WARN message.