### PR TITLE
Azure verify fix: Use list instead of metadata for SAS check

### DIFF
--- a/clouddump/config.py
+++ b/clouddump/config.py
@@ -297,17 +297,16 @@ def _verify_s3_bucket(job, job_id, results):
 def _verify_az_container(job, job_id, results):
     """Verify Azure Blob Storage container accessibility (warn only).
 
-    Uses a HEAD request with the SAS-token URL. Azure returns 200 if the
-    container exists and the token is valid — no blobs are listed.
+    Lists one blob to confirm the SAS token and container are valid.
+    Only requires Read + List permissions (no metadata access needed).
     """
     for blob in cfg(job, "blobstorages", []):
         source = cfg(blob, "source")
         if not source:
             continue
         label = f"Azure '{source.split('?')[0]}'"
-        # restype=container on the SAS URL returns container metadata only
         sep = "&" if "?" in source else "?"
-        url = f"{source}{sep}restype=container&comp=metadata"
+        url = f"{source}{sep}restype=container&comp=list&maxresults=1"
         req = urllib.request.Request(url, method="GET", headers={"User-Agent": "CloudDump"})
         try:
             with urllib.request.urlopen(req, timeout=10):


### PR DESCRIPTION
## Summary
- Azure SAS verify check used `comp=metadata` which requires permissions beyond Read+List
- Changed to `comp=list&maxresults=1` which works with minimal SAS permissions (Read+List)
- Fixes false WARN on startup for SAS tokens with standard permissions

## Test plan
- [ ] Unit tests pass (`124 passed, 7 skipped`)
- [ ] Verify against Azure container with Read+List only SAS token

🤖 Generated with [Claude Code](https://claude.com/claude-code)