### PR TITLE
Use [Degraded] startup subject when connectivity warnings present

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,19 @@ CloudDump exposes `GET /healthz` on port 8080 (configurable via `health_port`).
 time() - clouddump_last_run_finished > 48 * 3600
 ```
 
+### Email subjects
+
+CloudDump sends one startup email and one email per job run. Subject lines
+follow a fixed format so they're easy to filter on:
+
+| Subject | When |
+|---------|------|
+| `[Started] CloudDump {host}` | Process started, all connectivity checks passed |
+| `[Degraded] CloudDump {host}` | Process started, one or more connectivity checks returned a warning |
+| `[Success] CloudDump {host}: {job_id}` | Job succeeded on the first attempt |
+| `[Warning] CloudDump {host}: {job_id}` | Job succeeded, but only after one or more retries |
+| `[Failure] CloudDump {host}: {job_id}` | Job failed after all retry attempts |
+
 ## Contributing
 
 Contributions are welcome. Please open an issue first to discuss what you'd

--- a/clouddump/__main__.py
+++ b/clouddump/__main__.py
@@ -143,7 +143,9 @@ def main():
         f"CloudDump v{version}\n"
         f"https://github.com/ralftar/CloudDump"
     )
-    result = send_email(config, f"[Started] CloudDump {host}", startup_body)
+    has_warnings = any(line.startswith("WARN:") for line in connectivity)
+    subject_tag = "Degraded" if has_warnings else "Started"
+    result = send_email(config, f"[{subject_tag}] CloudDump {host}", startup_body)
     if result is True:
         log.info("Startup email sent.")
     elif result is None:


### PR DESCRIPTION
## Summary
- Startup email subject now uses `[Degraded]` instead of `[Started]` when any connectivity check returned a `WARN:` line, so partial-startup health is visible in inbox previews rather than buried in the body.
- Documented all five email subject formats (`[Started]`, `[Degraded]`, `[Success]`, `[Warning]`, `[Failure]`) in README under Monitoring.

## Test plan
- [ ] Start with all connectivity OK → subject is `[Started] CloudDump {host}`
- [ ] Start with at least one Azure container / S3 bucket / DB unreachable → subject is `[Degraded] CloudDump {host}`
- [ ] Body content unchanged in both cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)