### PR TITLE
Email report fixes: Redact only SAS sig, drop misleading backup size

### DIFF
--- a/clouddump/__init__.py
+++ b/clouddump/__init__.py
@@ -148,36 +148,6 @@ def fmt_bytes(n):
     return f"{n / 1024:.1f} KB"
 
 
-_PATH_KEYS = {
-    "s3bucket": ("buckets", "destination"),
-    "azstorage": ("blobstorages", "destination"),
-    "pgsql": ("servers", "backuppath"),
-    "mysql": ("servers", "backuppath"),
-    "github": ("organizations", "destination"),
-    "rsync": ("targets", "destination"),
-}
-
-
-def job_backup_size(job):
-    """Return total bytes stored in all backup destinations for *job*."""
-    job_type = cfg(job, "type")
-    mapping = _PATH_KEYS.get(job_type)
-    if not mapping:
-        return None
-    collection_key, field = mapping
-    total = 0
-    for target in cfg(job, collection_key, []):
-        path = cfg(target, field)
-        if path and os.path.isdir(path):
-            for dirpath, _dirnames, filenames in os.walk(path):
-                for f in filenames:
-                    try:
-                        total += os.path.getsize(os.path.join(dirpath, f))
-                    except OSError:
-                        pass
-    return total
-
-
 def net_bytes():
     """Read total rx/tx bytes from /proc/net/dev. Returns (rx, tx) or None."""
     try:
@@ -235,8 +205,8 @@ def redact(text):
         r"(AccountKey|SharedAccessKey)=[^;]*",
         r"\1=REDACTED", text, flags=re.IGNORECASE,
     )
-    # Azure SAS query parameters
-    text = re.sub(r"\?[^?]*(sig|se|st|sp|sr|sv)=[^&?]*", "?REDACTED", text)
+    # Azure SAS signature — only the sig= value is secret; other params (sv/se/st/sp/sr/...) are metadata
+    text = re.sub(r"([?&]sig=)[^&\s\"']*", r"\1REDACTED", text, flags=re.IGNORECASE)
     # Database connection URLs — match password between first : and last @ before host
     text = re.sub(
         r"(postgres|postgresql|mysql|mongodb|redis|amqp)://([^:]+):(.+)@([^@]+)$",

--- a/clouddump/__main__.py
+++ b/clouddump/__main__.py
@@ -13,7 +13,7 @@ import traceback
 from datetime import datetime, timezone
 
 import clouddump
-from clouddump import cfg, net_bytes, job_backup_size, redact, log, set_log_format, set_debug, _safe_remove, _LOG_DATEFMT
+from clouddump import cfg, net_bytes, redact, log, set_log_format, set_debug, _safe_remove, _LOG_DATEFMT
 from clouddump.config import load_config, validate_settings, validate_jobs, verify_connectivity
 from clouddump.cron import should_run
 from clouddump.email import send_email, send_job_report
@@ -269,13 +269,10 @@ def main():
                 else:
                     job_status = "Failure"
 
-                backup_bytes = job_backup_size(job)
-
                 send_job_report(config, version, host, job, result,
                                 job_t_start, job_t_end, logfile_paths,
                                 status=job_status, attempts_used=final_attempt,
-                                max_attempts=max_attempts,
-                                backup_bytes=backup_bytes)
+                                max_attempts=max_attempts)
 
                 for lf in logfile_paths:
                     _safe_remove(lf)

--- a/clouddump/email.py
+++ b/clouddump/email.py
@@ -8,7 +8,7 @@ from email.mime.application import MIMEApplication
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 
-from clouddump import cfg, fmt_bytes, log, redact
+from clouddump import cfg, log, redact
 
 
 def _resolve_smtp_security(config):
@@ -101,8 +101,7 @@ def format_job_config(job):
 
 
 def send_job_report(config, version, host, job, exit_code, t_start, t_end, logfile_paths,
-                    status=None, attempts_used=None, max_attempts=None,
-                    backup_bytes=None):
+                    status=None, attempts_used=None, max_attempts=None):
     """Send job completion email, optionally with log attachments.
 
     *logfile_paths* is a list of log files (one per attempt).  All are
@@ -126,10 +125,6 @@ def send_job_report(config, version, host, job, exit_code, t_start, t_end, logfi
     if attempts_used is not None and max_attempts is not None:
         attempt_info = f"Attempts: {attempts_used}/{max_attempts}\n"
 
-    backup_size_info = ""
-    if backup_bytes is not None:
-        backup_size_info = f"Backup size: {fmt_bytes(backup_bytes)}\n"
-
     summary = f"{status} | {job_id} ({job_type}) | {minutes}m {seconds}s"
     if attempts_used is not None and max_attempts is not None:
         summary += f" | attempt {attempts_used}/{max_attempts}"
@@ -144,7 +139,6 @@ def send_job_report(config, version, host, job, exit_code, t_start, t_end, logfi
         f"Started: {start_str}\n"
         f"Completed: {end_str}\n"
         f"Time elapsed: {minutes} minutes {seconds} seconds\n"
-        f"{backup_size_info}"
         f"\n"
         f"CONFIGURATION\n\n"
         f"{job_config_text}\n\n"

--- a/clouddump/job_azure.py
+++ b/clouddump/job_azure.py
@@ -25,7 +25,7 @@ def run_az_sync(blobstorage, logfile_path):
 
     log.info("Syncing Azure Blob Storage", extra={"source": source_stripped, "destination": destination})
 
-    cmd = ["azcopy", "sync", "--recursive", f"--delete-destination={'true' if delete else 'false'}", source, destination]
+    cmd = ["azcopy", "sync", f"--delete-destination={'true' if delete else 'false'}", source, destination]
 
     t0 = time.time()
     rc = run_cmd(cmd, logfile_path=logfile_path)

--- a/tests/test_runners.py
+++ b/tests/test_runners.py
@@ -158,7 +158,6 @@ class TestAzureRunner:
         cmd = calls[0][0]
         assert cmd[0] == "azcopy"
         assert cmd[1] == "sync"
-        assert "--recursive" in cmd
         assert "--delete-destination=true" in cmd
 
     def test_delete_disabled(self, monkeypatch, tmp_path, _tmp_logfile):

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -448,6 +448,8 @@ def test_validate_jobs_duplicate_id():
     # Azure
     ("AccountKey=abc123;EndpointSuffix=core.windows.net", "abc123"),
     ("https://store.blob.core.windows.net/c?sv=2021-08&sig=abc&se=2025-01-01", "sig=abc"),
+    ("https://store.blob.core.windows.net/c?SV=2021&SIG=abc&SE=2025", "SIG=abc"),
+    ("https://store.blob.core.windows.net/c?sv=2021&Sig=abc&se=2025", "Sig=abc"),
     # Database URLs
     ("postgres://admin:s3cret@db.example.com:5432/mydb", "s3cret"),
     ("postgresql://user:hunter2@localhost/app", "hunter2"),
@@ -481,6 +483,26 @@ def test_redact_strips_pem_private_key():
 def test_redact_ignores_clean_text():
     text = "Nothing sensitive here, just a normal log line."
     assert redact(text) == text
+
+
+def test_redact_sas_preserves_json_structure_across_multiple_urls():
+    import json
+    job = {
+        "id": "azdump1",
+        "blobstorages": [
+            {"destination": "/mnt/a", "source": "https://acct.blob.core.windows.net/a?sv=2024&sp=r&se=2030&st=2024&sr=c&sig=AAA"},
+            {"destination": "/mnt/b", "source": "https://acct.blob.core.windows.net/b?sv=2024&sig=BBB"},
+            {"destination": "/mnt/c", "source": "https://acct.blob.core.windows.net/c?sv=2024&sig=CCC"},
+        ],
+    }
+    result = redact(json.dumps(job, indent=2))
+    assert "AAA" not in result and "BBB" not in result and "CCC" not in result
+    assert result.count("sig=REDACTED") == 3
+    # Non-secret SAS metadata stays visible for debugging
+    assert "sv=2024" in result and "se=2030" in result and "sp=r" in result
+    assert '"destination": "/mnt/b"' in result
+    assert '"destination": "/mnt/c"' in result
+    assert result.rstrip().endswith("}")
 
 
 def test_validate_jobs_github_invalid_account_type():


### PR DESCRIPTION
## Summary

- **Redact fix**: `redact()` now replaces only the SAS `sig=` value instead of the whole query string. The previous regex (`\?[^?]*(sig|se|st|sp|sr|sv)=[^&?]*`) was too greedy — with multiple blobstorages in a job it consumed the JSON string boundaries between URLs, producing a truncated `?REDACTED?REDACTED?REDACTED…` run in the email body. It also removed non-secret metadata (expiry, permissions, resource scope) which is useful when debugging a failing job.
- **Drop "Backup size" from email**: the line reported total on-disk size of the destination directory via `os.walk`, not traffic for the current run. On a `Failure` where 0 bytes were transferred, it still showed e.g. "124.3 GB" from prior successful runs — misleading. Removed the line, the helper (`job_backup_size`), and the now-unused `_PATH_KEYS` mapping.
- **Drop redundant `--recursive` flag** from the `azcopy sync` invocation — sync recurses by default.
- **Regression tests**: multi-URL JSON preserves structure; SAS key matching is case-insensitive.

## Test plan
- [x] `pytest tests/` — 203 passed, 7 skipped
- [ ] Observe an email from a real run and confirm the body no longer shows the `?REDACTED?REDACTED…` artifact or the "Backup size" line

🤖 Generated with [Claude Code](https://claude.com/claude-code)