### PR TITLE
Connectivity verify fix: Use the job's own tool for every probe

### DIFF
--- a/clouddump/config.py
+++ b/clouddump/config.py
@@ -297,25 +297,20 @@ def _verify_s3_bucket(job, job_id, results):
 def _verify_az_container(job, job_id, results):
     """Verify Azure Blob Storage container accessibility (warn only).
 
-    Lists one blob to confirm the SAS token and container are valid.
-    Only requires Read + List permissions (no metadata access needed).
+    Runs ``azcopy list`` so the probe uses the same auth/URL-parsing
+    code path as the sync job. A urllib probe can accept a SAS URL
+    that ``azcopy`` later rejects (e.g. when the URL's query delimiter
+    is mangled), hiding failures until the scheduled job runs.
     """
     for blob in cfg(job, "blobstorages", []):
         source = cfg(blob, "source")
         if not source:
             continue
         label = f"Azure '{source.split('?')[0]}'"
-        sep = "&" if "?" in source else "?"
-        url = f"{source}{sep}restype=container&comp=list&maxresults=1"
-        req = urllib.request.Request(url, method="GET", headers={"User-Agent": "CloudDump"})
-        try:
-            with urllib.request.urlopen(req, timeout=10):
-                results.append(f"OK: {label} (job {job_id})")
-                log.info("%s verified (job %s).", label, job_id)
-        except (urllib.error.HTTPError, urllib.error.URLError) as exc:
-            reason = str(getattr(exc, "reason", exc))
-            results.append(f"WARN: {label} — {reason} (job {job_id})")
-            log.warning("%s failed (job %s): %s", label, job_id, reason)
+        _run_verify(
+            ["azcopy", "list", source, "--output-level=quiet"],
+            label, job_id, results,
+        )
 
 
 def _verify_rsync_ssh(job, job_id, results):

--- a/clouddump/config.py
+++ b/clouddump/config.py
@@ -4,8 +4,7 @@ import json
 import os
 import shutil
 import sys
-import urllib.error
-import urllib.request
+import urllib.parse
 
 from clouddump import cfg, log, validate_backup_path
 from clouddump.cron import validate_cron
@@ -24,7 +23,7 @@ TOOL_REQUIREMENTS = {
     "azstorage": ["azcopy"],
     "pgsql": ["pg_dump", "psql"],
     "mysql": ["mysqldump", "mysql"],
-    "github": ["github-backup", "git"],
+    "github": ["github-backup", "git", "curl"],
     "rsync": ["rsync", "ssh"],
 }
 
@@ -314,20 +313,28 @@ def _verify_az_container(job, job_id, results):
 
 
 def _verify_rsync_ssh(job, job_id, results):
-    """Verify SSH connectivity and remote path exists (warn only)."""
+    """Verify rsync-over-SSH connectivity (warn only).
+
+    Uses ``rsync --list-only`` so the probe traverses the same rsync
+    protocol + SSH transport the sync job uses. This also works with
+    restricted remote accounts (forced commands, ``rrsync``) where a
+    plain ``ssh test -d`` would fail.
+    """
     for target in cfg(job, "targets", []):
         source = cfg(target, "source")
         ssh_key = cfg(target, "ssh_key")
         ssh_port = str(cfg(target, "ssh_port", "22"))
         if not source or not ssh_key or ":" not in source:
             continue
-        host_part, remote_path = source.split(":", 1)
-        _run_verify([
-            "ssh", "-i", ssh_key, "-p", ssh_port,
-            "-o", "StrictHostKeyChecking=accept-new",
-            "-o", "BatchMode=yes", "-o", "ConnectTimeout=5",
-            host_part, f"test -d {remote_path}",
-        ], f"SSH '{source}'", job_id, results, timeout=10)
+        ssh_cmd = (
+            f"ssh -i {ssh_key} -p {ssh_port} "
+            "-o StrictHostKeyChecking=accept-new "
+            "-o BatchMode=yes -o ConnectTimeout=5"
+        )
+        _run_verify(
+            ["rsync", "-n", "--list-only", "-e", ssh_cmd, f"{source}/"],
+            f"rsync '{source}'", job_id, results, timeout=10,
+        )
 
 
 def _verify_db_connection(job, job_id, job_type, results):
@@ -353,7 +360,11 @@ def _verify_db_connection(job, job_id, job_type, results):
 
 
 def _verify_github_token(job, job_id, results):
-    """Verify GitHub tokens and accounts are accessible (warn only)."""
+    """Verify GitHub tokens and accounts are accessible (warn only).
+
+    Uses ``curl`` for parity with the other subprocess-based probes and
+    to keep all verify paths out of the Python HTTP stack.
+    """
     for account in cfg(job, "organizations", []):
         acct_name = cfg(account, "name")
         token = cfg(account, "token")
@@ -361,21 +372,17 @@ def _verify_github_token(job, job_id, results):
         if not acct_name or not token or acct_type not in VALID_GITHUB_ACCOUNT_TYPES:
             continue
         endpoint = "users" if acct_type == "user" else "orgs"
-        url = f"https://api.github.com/{endpoint}/{urllib.request.quote(acct_name, safe='')}"
-        req = urllib.request.Request(url, headers={
-            "Authorization": f"token {token}",
-            "Accept": "application/vnd.github+json",
-            "User-Agent": "CloudDump",
-        })
-        label = f"GitHub {acct_type} '{acct_name}'"
-        try:
-            with urllib.request.urlopen(req, timeout=10):
-                results.append(f"OK: {label} (job {job_id})")
-                log.info("%s verified (job %s).", label, job_id)
-        except (urllib.error.HTTPError, urllib.error.URLError) as exc:
-            reason = str(getattr(exc, "reason", exc))
-            results.append(f"WARN: {label} — {reason} (job {job_id})")
-            log.warning("%s failed (job %s): %s", label, job_id, reason)
+        url = f"https://api.github.com/{endpoint}/{urllib.parse.quote(acct_name, safe='')}"
+        _run_verify(
+            [
+                "curl", "-sSf", "--max-time", "10",
+                "-H", f"Authorization: Bearer {token}",
+                "-H", "Accept: application/vnd.github+json",
+                "-H", "User-Agent: CloudDump",
+                "-o", os.devnull, url,
+            ],
+            f"GitHub {acct_type} '{acct_name}'", job_id, results, timeout=15,
+        )
 
 
 def _verify_pgsql(job, job_id, results):

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -580,20 +580,26 @@ def test_verify_s3_bucket_failure(mock_run):
     assert any("WARN" in r and "S3" in r for r in results)
 
 
-@patch("clouddump.config.urllib.request.urlopen")
-def test_verify_az_container_ok(mock_urlopen):
-    mock_urlopen.return_value.__enter__ = lambda s: s
-    mock_urlopen.return_value.__exit__ = lambda s, *a: None
-    job = _job(type="azstorage", blobstorages=[{
-        "source": "https://account.blob.core.windows.net/container?sv=2021&sig=xxx"}])
+@patch("subprocess.run")
+def test_verify_az_container_ok(mock_run):
+    mock_run.return_value.returncode = 0
+    mock_run.return_value.stdout = ""
+    mock_run.return_value.stderr = ""
+    source = "https://account.blob.core.windows.net/container?sv=2021&sig=xxx"
+    job = _job(type="azstorage", blobstorages=[{"source": source}])
     results = verify_connectivity([job])
     assert any("OK" in r and "Azure" in r for r in results)
+    cmd = mock_run.call_args[0][0]
+    assert cmd[0] == "azcopy"
+    assert cmd[1] == "list"
+    assert source in cmd
 
 
-@patch("clouddump.config.urllib.request.urlopen")
-def test_verify_az_container_failure(mock_urlopen):
-    mock_urlopen.side_effect = urllib.error.HTTPError(
-        "https://account.blob.core.windows.net/", 403, "Forbidden", {}, None)
+@patch("subprocess.run")
+def test_verify_az_container_failure(mock_run):
+    mock_run.return_value.returncode = 1
+    mock_run.return_value.stdout = ""
+    mock_run.return_value.stderr = "RESPONSE 401: NoAuthenticationInformation\n"
     job = _job(type="azstorage", blobstorages=[{
         "source": "https://account.blob.core.windows.net/container?sv=2021&sig=bad"}])
     results = verify_connectivity([job])

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -515,19 +515,26 @@ def test_validate_jobs_github_invalid_account_type():
 # ── verify_connectivity ─────────────────────────────────────────────────────
 
 
-@patch("clouddump.config.urllib.request.urlopen")
-def test_verify_connectivity_github_token(mock_urlopen):
-    mock_urlopen.return_value.__enter__ = lambda s: s
-    mock_urlopen.return_value.__exit__ = lambda s, *a: None
+@patch("subprocess.run")
+def test_verify_connectivity_github_token(mock_run):
+    mock_run.return_value.returncode = 0
+    mock_run.return_value.stdout = ""
+    mock_run.return_value.stderr = ""
     job = _job(type="github", organizations=[{"name": "my-org", "token": "ghp_xxx"}])
     results = verify_connectivity([job])
     assert any("OK" in r and "GitHub" in r for r in results)
+    cmd = mock_run.call_args[0][0]
+    assert cmd[0] == "curl"
+    assert "https://api.github.com/orgs/my-org" in cmd
+    # Token must be passed as an Authorization header, not in the URL.
+    assert not any("ghp_xxx" in a for a in cmd if a.startswith("http"))
 
 
-@patch("clouddump.config.urllib.request.urlopen")
-def test_verify_connectivity_github_warns_on_failure(mock_urlopen):
-    mock_urlopen.side_effect = urllib.error.HTTPError(
-        "https://api.github.com/orgs/x", 401, "Unauthorized", {}, None)
+@patch("subprocess.run")
+def test_verify_connectivity_github_warns_on_failure(mock_run):
+    mock_run.return_value.returncode = 22  # curl exit code for HTTP >= 400 with -f
+    mock_run.return_value.stdout = ""
+    mock_run.return_value.stderr = "curl: (22) The requested URL returned error: 401\n"
     job = _job(type="github", organizations=[{"name": "my-org", "token": "ghp_bad"}])
     results = verify_connectivity([job])
     assert any("WARN" in r for r in results)
@@ -614,7 +621,7 @@ def test_verify_rsync_ssh_ok(mock_run):
     job = _job(type="rsync", targets=[{
         "source": "user@host.example.com:/data", "ssh_key": "/config/id_ed25519"}])
     results = verify_connectivity([job])
-    assert any("OK" in r and "SSH" in r for r in results)
+    assert any("OK" in r and "rsync" in r for r in results)
 
 
 @patch("subprocess.run")
@@ -625,7 +632,7 @@ def test_verify_rsync_ssh_failure(mock_run):
     job = _job(type="rsync", targets=[{
         "source": "user@host.example.com:/data", "ssh_key": "/config/id_ed25519"}])
     results = verify_connectivity([job])
-    assert any("WARN" in r and "SSH" in r for r in results)
+    assert any("WARN" in r and "rsync" in r for r in results)
 
 
 @patch("subprocess.run")
@@ -639,7 +646,7 @@ def test_verify_rsync_ssh_ok_ignores_host_key_notice(mock_run):
     job = _job(type="rsync", targets=[{
         "source": "user@10.0.0.1:/data", "ssh_key": "/config/id_ed25519"}])
     results = verify_connectivity([job])
-    assert any("OK" in r and "SSH" in r for r in results)
+    assert any("OK" in r and "rsync" in r for r in results)
     assert not any("WARN" in r for r in results)
 
 


### PR DESCRIPTION
## Summary

Every connectivity probe should use the same tool (and same auth/URL-parser code path) as the actual backup job, so that \"verify OK\" genuinely implies \"the job will connect.\" Three probes drifted from this:

- **Azure**: \`urllib.request.urlopen\` probed the SAS URL, while the job uses \`azcopy sync\`. Different URL parser. A recent incident had \`urllib\` return 200 on a URL where \`&\` delimiters had been corrupted upstream, while \`azcopy\` then sent the request with no SAS and got 401 \`NoAuthenticationInformation\`. → Now \`azcopy list --output-level=quiet\`.
- **Rsync**: \`ssh host \"test -d path\"\` required a real remote shell. Fine for plain shell accounts, but the job uses the rsync protocol, which also works with forced commands and \`rrsync\` wrappers that reject arbitrary shell invocation. → Now \`rsync -n --list-only -e ssh …\`, matching the \`_find_old_files\` helper already in the rsync job itself.
- **GitHub**: \`urllib.request.urlopen\` against the GitHub API, while the job uses the \`github-backup\` pip tool. Low-risk divergence in practice (stable REST API, simple Bearer auth), but leaves the verify path as the only caller of the Python HTTP stack. → Now \`curl -sSf …\` for parity with the other subprocess probes.

After this PR every verify is a \`subprocess.run\` via \`_run_verify\` — no more urllib in \`config.py\`. \`TOOL_REQUIREMENTS[\"github\"]\` now includes \`curl\`.

## Test plan
- [x] \`pytest tests/\` — 203 passed, 7 skipped. Existing verify tests rewritten to mock \`subprocess.run\` and assert the expected command shape.
- [ ] On deploy, confirm the startup email's \`CONNECTIVITY\` section still lists OK/WARN per target for all four probe types.

🤖 Generated with [Claude Code](https://claude.com/claude-code)