### PR TITLE
Job config: debug wires up azcopy verbose mode; add enabled=false flag

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -69,6 +69,7 @@ kubectl exec deploy/clouddump -- kill -USR1 1
 |-----|----------|---------|-------------|
 | `id` | Yes | — | Unique job identifier |
 | `type` | Yes | — | `s3bucket`, `azstorage`, `pgsql`, `mysql`, `github`, or `rsync` |
+| `enabled` | No | `true` | Skip the job when `false`. Still validated at startup. |
 | `timeout` | No | `604800` (7 days) | Job timeout in seconds |
 | `retries` | No | `3` | Number of attempts on failure |
 

--- a/clouddump/__main__.py
+++ b/clouddump/__main__.py
@@ -185,6 +185,10 @@ def main():
                     continue
 
                 job_type = cfg(job, "type")
+                if not cfg(job, "enabled", True):
+                    log.info("Skipping disabled job", extra={"job_id": job_id, "job_type": job_type})
+                    continue
+
                 clouddump.current_job = job_id
                 log.info("Starting job", extra={"job_type": job_type})
 

--- a/clouddump/config.py
+++ b/clouddump/config.py
@@ -238,7 +238,8 @@ def validate_jobs(jobs):
                               acct_type, acct_name, job_id, ", ".join(sorted(VALID_GITHUB_ACCOUNT_TYPES)))
                     errors += 1
 
-        summaries.append(f"ID: {job_id}\nType: {job_type}")
+        disabled_tag = "" if cfg(job, "enabled", True) else " (DISABLED)"
+        summaries.append(f"ID: {job_id}{disabled_tag}\nType: {job_type}")
 
     return errors, "\n\n".join(summaries)
 
@@ -480,6 +481,8 @@ def verify_connectivity(jobs):
         job_id = cfg(job, "id")
         job_type = cfg(job, "type")
         if not job_id or not job_type:
+            continue
+        if not cfg(job, "enabled", True):
             continue
 
         if job_type == "s3bucket":

--- a/clouddump/job_azure.py
+++ b/clouddump/job_azure.py
@@ -3,6 +3,7 @@
 import os
 import time
 
+import clouddump
 from clouddump import cfg, log, run_cmd
 
 
@@ -25,7 +26,10 @@ def run_az_sync(blobstorage, logfile_path):
 
     log.info("Syncing Azure Blob Storage", extra={"source": source_stripped, "destination": destination})
 
-    cmd = ["azcopy", "sync", f"--delete-destination={'true' if delete else 'false'}", source, destination]
+    cmd = ["azcopy", "sync", f"--delete-destination={'true' if delete else 'false'}"]
+    if clouddump.debug:
+        cmd += ["--output-level=verbose", "--log-level=DEBUG"]
+    cmd += [source, destination]
 
     t0 = time.time()
     rc = run_cmd(cmd, logfile_path=logfile_path)

--- a/config.schema.json
+++ b/config.schema.json
@@ -83,6 +83,7 @@
           "enum": ["s3bucket", "azstorage", "pgsql", "mysql", "github", "rsync"],
           "description": "Job type."
         },
+        "enabled": { "type": "boolean", "default": true, "description": "Skip the job when false. Still validated at startup." },
         "timeout": { "type": "integer", "minimum": 1, "default": 604800, "description": "Timeout in seconds." },
         "retries": { "type": "integer", "minimum": 1, "default": 3, "description": "Number of retry attempts." },
         "buckets": { "type": "array", "items": { "$ref": "#/$defs/s3_bucket" } },

--- a/tests/test_runners.py
+++ b/tests/test_runners.py
@@ -170,6 +170,34 @@ class TestAzureRunner:
 
         assert "--delete-destination=false" in calls[0][0]
 
+    def test_debug_adds_verbose_flags(self, monkeypatch, tmp_path, _tmp_logfile):
+        import clouddump
+        from clouddump.job_azure import run_az_sync
+
+        dest = str(tmp_path / "azout")
+        calls = _capture_cmd(monkeypatch, "clouddump.job_azure.run_cmd")
+
+        monkeypatch.setattr(clouddump, "debug", True)
+        run_az_sync(self._cfg(destination=dest), _tmp_logfile)
+
+        cmd = calls[0][0]
+        assert "--output-level=verbose" in cmd
+        assert "--log-level=DEBUG" in cmd
+
+    def test_no_debug_flags_by_default(self, monkeypatch, tmp_path, _tmp_logfile):
+        import clouddump
+        from clouddump.job_azure import run_az_sync
+
+        dest = str(tmp_path / "azout")
+        calls = _capture_cmd(monkeypatch, "clouddump.job_azure.run_cmd")
+
+        monkeypatch.setattr(clouddump, "debug", False)
+        run_az_sync(self._cfg(destination=dest), _tmp_logfile)
+
+        cmd = calls[0][0]
+        assert not any(a.startswith("--output-level") for a in cmd)
+        assert not any(a.startswith("--log-level") for a in cmd)
+
     def test_missing_source(self, monkeypatch, _tmp_logfile):
         from clouddump.job_azure import run_az_sync
 

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -425,6 +425,21 @@ def test_validate_jobs_duplicate_id():
     assert errors >= 1
 
 
+def test_validate_jobs_disabled_tag_in_summary():
+    errors, summary = validate_jobs([_job(enabled=False)])
+    assert errors == 0
+    assert "DISABLED" in summary
+
+
+def test_verify_connectivity_skips_disabled_job():
+    # Without a network mock, a live verify would be attempted; enabled=false
+    # must short-circuit before any verify helper runs.
+    job = _job(type="azstorage", enabled=False, blobstorages=[{
+        "source": "https://account.blob.core.windows.net/container?sv=2021&sig=xxx"}])
+    results = verify_connectivity([job])
+    assert results == []
+
+
 # ── redact ───────────────────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

Two small, related changes that make diagnosing the azure job easier and let us silence one job at a time while validating the rest.

### `debug = true` now tells azcopy to be verbose

\`job_azure.run_az_sync\` used to call azcopy at default verbosity. When a sync failed, all the useful HTTP-level detail sat in azcopy's own per-job log under \`~/.azcopy/<uuid>.log\` which CloudDump never surfaces. The stdout we streamed said nothing more than \`RESPONSE 401 NoAuthenticationInformation\`.

When the top-level \`debug\` flag is on, we now pass:

- \`--output-level=verbose\` — azcopy writes HTTP details to stderr, which \`run_cmd\` already streams into the per-attempt logfile (and to the console).
- \`--log-level=DEBUG\` — azcopy's own per-job log gets maximum detail. (We still don't read that file back, but it's there for manual inspection after the fact.)

### New per-job \`enabled\` field (default \`true\`)

Setting \`enabled: false\` on any job in the array now causes:

- \`__main__\` to skip execution (logs \`Skipping disabled job\`).
- \`verify_connectivity\` to skip the probe.
- \`validate_jobs\` to still run and tag the summary with \`(DISABLED)\` so it's visible in the startup email.

Lets us freeze pgsql while we validate that azstorage is finally healthy, without commenting blocks out of config.

Schema (\`config.schema.json\`) and \`CONFIGURATION.md\` updated.

## Test plan
- [x] \`pytest tests/\` — 207 passed, 7 skipped (added 4 new tests)
- [ ] On deploy, confirm the startup email's JOBS section shows \`(DISABLED)\` for any \`enabled=false\` entry and the run skips it.
- [ ] Confirm a failing azcopy run with \`debug=true\` attaches a log with HTTP verbose output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)