### PR TITLE
Azure debug fix: Drop invalid --output-level=verbose flag

### DIFF
--- a/clouddump/config.py
+++ b/clouddump/config.py
@@ -307,9 +307,12 @@ def _verify_az_container(job, job_id, results):
         if not source:
             continue
         label = f"Azure '{source.split('?')[0]}'"
+        # azcopy list walks the full blob inventory; containers with ~100k+
+        # blobs routinely need well over the 15s default. 150s is a practical
+        # ceiling that still bounds startup.
         _run_verify(
             ["azcopy", "list", source, "--output-level=quiet"],
-            label, job_id, results,
+            label, job_id, results, timeout=150,
         )
 
 

--- a/clouddump/job_azure.py
+++ b/clouddump/job_azure.py
@@ -28,7 +28,10 @@ def run_az_sync(blobstorage, logfile_path):
 
     cmd = ["azcopy", "sync", f"--delete-destination={'true' if delete else 'false'}"]
     if clouddump.debug:
-        cmd += ["--output-level=verbose", "--log-level=DEBUG"]
+        # azcopy's --output-level only supports essential/quiet/default — there
+        # is no verbose stdout mode. HTTP-level detail goes to the per-job
+        # log file under ~/.azcopy/<uuid>.log when --log-level=DEBUG is set.
+        cmd += ["--log-level=DEBUG"]
     cmd += [source, destination]
 
     t0 = time.time()

--- a/tests/test_runners.py
+++ b/tests/test_runners.py
@@ -170,7 +170,7 @@ class TestAzureRunner:
 
         assert "--delete-destination=false" in calls[0][0]
 
-    def test_debug_adds_verbose_flags(self, monkeypatch, tmp_path, _tmp_logfile):
+    def test_debug_adds_log_level_flag(self, monkeypatch, tmp_path, _tmp_logfile):
         import clouddump
         from clouddump.job_azure import run_az_sync
 
@@ -181,8 +181,9 @@ class TestAzureRunner:
         run_az_sync(self._cfg(destination=dest), _tmp_logfile)
 
         cmd = calls[0][0]
-        assert "--output-level=verbose" in cmd
         assert "--log-level=DEBUG" in cmd
+        # --output-level only accepts essential/quiet/default — no verbose.
+        assert not any(a.startswith("--output-level") for a in cmd)
 
     def test_no_debug_flags_by_default(self, monkeypatch, tmp_path, _tmp_logfile):
         import clouddump


### PR DESCRIPTION
## Related
- Fixes a regression from #226 that broke the azstorage job on v1.4.8
- Also raises the azure verify timeout so large containers don't falsely WARN at startup

## Summary

**1. Drop \`--output-level=verbose\`.** #226 added \`--output-level=verbose --log-level=DEBUG\` to \`azcopy sync\` when \`debug=true\`. Turns out \`--output-level\` only accepts \`essential\`, \`quiet\`, or \`default\` — there is no \`verbose\`. Every sync under v1.4.8 exited before any HTTP call:

\`\`\`
Error: couldn't parse "verbose" into a "OutputVerbosity"
--output-level string     Define the output verbosity. Available levels: essential, quiet. (default "default")
\`\`\`

Keep \`--log-level=DEBUG\` (valid; makes azcopy write full HTTP traces to \`~/.azcopy/<uuid>.log\`), drop the bad flag. Azcopy simply has no verbose-stdout mode.

**2. Azure verify timeout raised from 15s to 150s.** \`_verify_az_container\` runs \`azcopy list\`, which walks the full blob inventory of the container. Containers with \~100k+ blobs (\`cylinder\` on shade has ~120k) regularly exceed 15s and surface a false WARN even when the SAS is fine and the sync itself would succeed. 150s is a practical ceiling.

## Test plan
- [x] \`pytest tests/\` — 207 passed, 7 skipped; azure-debug test now asserts \`--output-level=*\` is absent.
- [ ] After release + deploy, verify:
  - azstorage job runs past the sync invocation
  - startup email shows OK (not WARN) for \`cylinder\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)