### PR TITLE
Job logging: per-target labels, per-attempt summary, azcopy debug sidecar

### DIFF
--- a/clouddump/__main__.py
+++ b/clouddump/__main__.py
@@ -278,7 +278,10 @@ def main():
                                 status=job_status, attempts_used=final_attempt,
                                 max_attempts=max_attempts)
 
+                import glob
                 for lf in logfile_paths:
+                    for sidecar in glob.glob(f"{lf}.*.log"):
+                        _safe_remove(sidecar)
                     _safe_remove(lf)
 
                 if result == 0:

--- a/clouddump/email.py
+++ b/clouddump/email.py
@@ -150,6 +150,7 @@ def send_job_report(config, version, host, job, exit_code, t_start, t_end, logfi
 
     attachments = []
     if email_log_attached:
+        import glob
         # Support both a single path (string) and a list of paths
         paths = logfile_paths if isinstance(logfile_paths, list) else [logfile_paths]
         timestamp = datetime.fromtimestamp(t_start, tz=timezone.utc).strftime("%Y%m%d-%H%M%S")
@@ -158,6 +159,13 @@ def send_job_report(config, version, host, job, exit_code, t_start, t_end, logfi
                 suffix = f"-attempt{i}" if len(paths) > 1 else ""
                 name = f"clouddump-{job_id}-{timestamp}{suffix}.log"
                 attachments.append((path, name))
+            # Sidecars written by runners (e.g. job_azure's azcopy job log).
+            for sidecar in sorted(glob.glob(f"{path}.*.log")):
+                if os.path.isfile(sidecar):
+                    tag = sidecar[len(path) + 1:-len(".log")]
+                    suffix = f"-attempt{i}" if len(paths) > 1 else ""
+                    name = f"clouddump-{job_id}-{timestamp}{suffix}-{tag}.log"
+                    attachments.append((sidecar, name))
 
     subject = f"[{status}] CloudDump {host}: {job_id}"
     send_email(config, subject, body, attachments)

--- a/clouddump/job_azure.py
+++ b/clouddump/job_azure.py
@@ -1,21 +1,24 @@
 """Azure Blob Storage sync job runner."""
 
 import os
+import re
 import time
 
 import clouddump
 from clouddump import cfg, log, redact, run_cmd
 
 _AZCOPY_JOB_LOG_DIR = os.path.expanduser("~/.azcopy")
+_SAFE_NAME_RE = re.compile(r"[^A-Za-z0-9_.-]")
 
 
-def _append_azcopy_job_log(logfile_path):
-    """Append the most recent azcopy per-job log to *logfile_path*.
+def _copy_azcopy_job_log(sidecar_path):
+    """Copy the most recent azcopy per-job log to *sidecar_path*, redacted.
 
     Azcopy writes a separate `<uuid>.log` in ``~/.azcopy/`` per invocation
     with the HTTP-level detail requested by ``--log-level=DEBUG``. Its
-    stdout only shows the progress summary. When debug is on we surface
-    that detail in our own logfile so it reaches the job-report email.
+    stdout only shows the progress summary. When debug is on we copy that
+    per-job log to a sidecar file next to the attempt's logfile so
+    ``send_job_report`` picks it up as its own email attachment.
     """
     try:
         logs = [
@@ -30,13 +33,17 @@ def _append_azcopy_job_log(logfile_path):
     newest = max(logs, key=os.path.getmtime)
     try:
         with open(newest, encoding="utf-8", errors="replace") as src, \
-             open(logfile_path, "a", encoding="utf-8") as dst:
-            dst.write(f"\n--- azcopy job log: {os.path.basename(newest)} ---\n")
+             open(sidecar_path, "w", encoding="utf-8") as dst:
             for line in src:
                 dst.write(redact(line))
-            dst.write("--- end azcopy job log ---\n")
     except OSError as exc:
-        log.warning("Could not append azcopy job log %s: %s", newest, exc)
+        log.warning("Could not copy azcopy job log %s: %s", newest, exc)
+
+
+def _container_from_source(source):
+    """Extract the container name (last path segment before ?) from a blob URL."""
+    path = source.split("?", 1)[0]
+    return path.rstrip("/").rsplit("/", 1)[-1] or "unknown"
 
 
 def run_az_sync(blobstorage, logfile_path):
@@ -54,9 +61,11 @@ def run_az_sync(blobstorage, logfile_path):
         return 1
 
     source_stripped = source.split("?")[0]
+    container = _container_from_source(source)
     os.makedirs(destination, exist_ok=True)
 
-    log.info("Syncing Azure Blob Storage", extra={"source": source_stripped, "destination": destination})
+    log.info("Syncing blobstorage '%s' → %s", container, destination,
+             extra={"container": container, "source": source_stripped, "destination": destination})
 
     cmd = ["azcopy", "sync", f"--delete-destination={'true' if delete else 'false'}"]
     if clouddump.debug:
@@ -71,10 +80,14 @@ def run_az_sync(blobstorage, logfile_path):
     elapsed = int(time.time() - t0)
 
     if clouddump.debug:
-        _append_azcopy_job_log(logfile_path)
+        safe = _SAFE_NAME_RE.sub("_", container)
+        sidecar = f"{logfile_path}.{safe}.azcopy.log"
+        _copy_azcopy_job_log(sidecar)
 
     if rc != 0:
-        log.error("Azure sync failed", extra={"source": source_stripped, "elapsed_s": elapsed})
+        log.error("Blobstorage '%s' failed in %ds", container, elapsed,
+                  extra={"container": container, "source": source_stripped, "elapsed_s": elapsed})
     else:
-        log.info("Azure sync completed", extra={"source": source_stripped, "elapsed_s": elapsed})
+        log.info("Blobstorage '%s' completed in %ds", container, elapsed,
+                 extra={"container": container, "source": source_stripped, "elapsed_s": elapsed})
     return rc

--- a/clouddump/job_azure.py
+++ b/clouddump/job_azure.py
@@ -4,7 +4,39 @@ import os
 import time
 
 import clouddump
-from clouddump import cfg, log, run_cmd
+from clouddump import cfg, log, redact, run_cmd
+
+_AZCOPY_JOB_LOG_DIR = os.path.expanduser("~/.azcopy")
+
+
+def _append_azcopy_job_log(logfile_path):
+    """Append the most recent azcopy per-job log to *logfile_path*.
+
+    Azcopy writes a separate `<uuid>.log` in ``~/.azcopy/`` per invocation
+    with the HTTP-level detail requested by ``--log-level=DEBUG``. Its
+    stdout only shows the progress summary. When debug is on we surface
+    that detail in our own logfile so it reaches the job-report email.
+    """
+    try:
+        logs = [
+            os.path.join(_AZCOPY_JOB_LOG_DIR, f)
+            for f in os.listdir(_AZCOPY_JOB_LOG_DIR)
+            if f.endswith(".log") and not f.endswith("-scanning.log")
+        ]
+    except FileNotFoundError:
+        return
+    if not logs:
+        return
+    newest = max(logs, key=os.path.getmtime)
+    try:
+        with open(newest, encoding="utf-8", errors="replace") as src, \
+             open(logfile_path, "a", encoding="utf-8") as dst:
+            dst.write(f"\n--- azcopy job log: {os.path.basename(newest)} ---\n")
+            for line in src:
+                dst.write(redact(line))
+            dst.write("--- end azcopy job log ---\n")
+    except OSError as exc:
+        log.warning("Could not append azcopy job log %s: %s", newest, exc)
 
 
 def run_az_sync(blobstorage, logfile_path):
@@ -37,6 +69,9 @@ def run_az_sync(blobstorage, logfile_path):
     t0 = time.time()
     rc = run_cmd(cmd, logfile_path=logfile_path)
     elapsed = int(time.time() - t0)
+
+    if clouddump.debug:
+        _append_azcopy_job_log(logfile_path)
 
     if rc != 0:
         log.error("Azure sync failed", extra={"source": source_stripped, "elapsed_s": elapsed})

--- a/clouddump/jobs.py
+++ b/clouddump/jobs.py
@@ -17,6 +17,28 @@ _RUNNERS = {
     "rsync": ("targets", run_rsync_sync),
 }
 
+# For the per-target summary at the end of each attempt. The field we read is
+# typically enough to identify the target ("asset", "db.example.com", etc.).
+_TARGET_LABEL_FIELDS = {
+    "s3bucket": "source",
+    "azstorage": "source",
+    "pgsql": "host",
+    "mysql": "host",
+    "github": "name",
+    "rsync": "source",
+}
+
+
+def _target_label(target, job_type):
+    field = _TARGET_LABEL_FIELDS.get(job_type)
+    if not field:
+        return "?"
+    val = cfg(target, field) or "?"
+    if job_type in ("s3bucket", "azstorage", "rsync"):
+        # Strip query strings and protocol noise so the label fits one line.
+        val = val.split("?", 1)[0]
+    return val
+
 
 def execute_job(job, logfile_path):
     """Dispatch a job to the appropriate runner by type. Returns exit code.
@@ -38,8 +60,15 @@ def execute_job(job, logfile_path):
         return 1
 
     rc = 0
+    results = []
     for target in targets:
         r = runner(target, logfile_path)
+        results.append((_target_label(target, job_type), r))
         if r != 0:
             rc = max(rc, r)
+
+    if len(results) > 1:
+        lines = [f"  {'OK  ' if r == 0 else 'FAIL'}  {label}" for label, r in results]
+        ok = sum(1 for _, r in results if r == 0)
+        log.info("Job summary (%d/%d OK):\n%s", ok, len(results), "\n".join(lines))
     return rc

--- a/tests/test_runners.py
+++ b/tests/test_runners.py
@@ -185,7 +185,9 @@ class TestAzureRunner:
         # --output-level only accepts essential/quiet/default — no verbose.
         assert not any(a.startswith("--output-level") for a in cmd)
 
-    def test_debug_appends_azcopy_job_log(self, monkeypatch, tmp_path, _tmp_logfile):
+    def test_debug_writes_azcopy_sidecar_log(self, monkeypatch, tmp_path, _tmp_logfile):
+        """Debug mode copies azcopy's per-job log to a sidecar for email."""
+        import glob
         import clouddump
         from clouddump import job_azure
         from clouddump.job_azure import run_az_sync
@@ -202,9 +204,15 @@ class TestAzureRunner:
 
         run_az_sync(self._cfg(destination=dest), _tmp_logfile)
 
-        tail = open(_tmp_logfile, encoding="utf-8").read()
-        assert "azcopy job log" in tail
-        assert "RESPONSE 200" in tail
+        sidecars = glob.glob(f"{_tmp_logfile}.*.azcopy.log")
+        assert len(sidecars) == 1
+        body = open(sidecars[0], encoding="utf-8").read()
+        assert "RESPONSE 200" in body
+        # Sidecar lives next to the attempt log, tagged with the container name.
+        assert "container.azcopy.log" in sidecars[0]
+        # Main logfile must not be polluted with the verbose trace.
+        main = open(_tmp_logfile, encoding="utf-8").read()
+        assert "RESPONSE 200" not in main
 
     def test_no_debug_flags_by_default(self, monkeypatch, tmp_path, _tmp_logfile):
         import clouddump

--- a/tests/test_runners.py
+++ b/tests/test_runners.py
@@ -185,6 +185,27 @@ class TestAzureRunner:
         # --output-level only accepts essential/quiet/default — no verbose.
         assert not any(a.startswith("--output-level") for a in cmd)
 
+    def test_debug_appends_azcopy_job_log(self, monkeypatch, tmp_path, _tmp_logfile):
+        import clouddump
+        from clouddump import job_azure
+        from clouddump.job_azure import run_az_sync
+
+        dest = str(tmp_path / "azout")
+        open(_tmp_logfile, "w").close()
+        azcopy_log_dir = tmp_path / "azcopy"
+        azcopy_log_dir.mkdir()
+        job_log = azcopy_log_dir / "11111111-2222-3333-4444-555555555555.log"
+        job_log.write_text("2026-04-20 GET https://account.blob.core.windows.net/container\nRESPONSE 200\n")
+        monkeypatch.setattr(job_azure, "_AZCOPY_JOB_LOG_DIR", str(azcopy_log_dir))
+        _capture_cmd(monkeypatch, "clouddump.job_azure.run_cmd")
+        monkeypatch.setattr(clouddump, "debug", True)
+
+        run_az_sync(self._cfg(destination=dest), _tmp_logfile)
+
+        tail = open(_tmp_logfile, encoding="utf-8").read()
+        assert "azcopy job log" in tail
+        assert "RESPONSE 200" in tail
+
     def test_no_debug_flags_by_default(self, monkeypatch, tmp_path, _tmp_logfile):
         import clouddump
         from clouddump.job_azure import run_az_sync


### PR DESCRIPTION
## Summary

Three changes so reading the log actually tells you what happened, without flooding the console.

### 1. Per-container log lines in run_az_sync
Old \`Syncing Azure Blob Storage\` became \`Syncing blobstorage 'cylinder' → /mnt/clouddump/azdump/cylinder\`. Completion line gets the same \`'<container>'\` prefix. No more scrolling back through URLs to figure out which block belongs to which container.

### 2. Per-attempt summary in execute_job
Generic across job types. After all targets in a job have run, emit one block:

\`\`\`
Job summary (6/6 OK):
  OK    https://vendanor.blob.core.windows.net/asset
  OK    https://vendanor.blob.core.windows.net/cylinder
  OK    https://vendanor.blob.core.windows.net/edge-compute-image
  ...
\`\`\`

Labels come from a per-type field (\`source\` for s3/az/rsync, \`host\` for pg/mysql, \`name\` for github) — nothing fancy, just something the operator can eyeball.

### 3. Azcopy \`--log-level=DEBUG\` sidecar as separate email attachment
Azcopy has no verbose-stdout mode — the HTTP detail it produces only goes to \`~/.azcopy/<uuid>.log\`. When \`debug\` is on, \`run_az_sync\` copies that file (redacted) to a sidecar next to the attempt's logfile, named \`<logfile>.<container>.azcopy.log\`. \`email.py\` globs those siblings and attaches each as its own file (\`clouddump-<job>-<ts>-<container>.azcopy.log\`). Stays out of the main streamed log so \`docker logs\` isn't flooded. \`__main__\` cleanup removes the sidecars after email.

## Test plan
- [x] \`pytest tests/\` — 208 passed, 7 skipped (rewrote the azure debug test to assert on the sidecar, not an inlined blob in the main log)
- [ ] Deploy + trigger. Expect per-container log lines, a summary block at the end of each attempt, and one extra \`.azcopy.log\` attachment per blobstorage on the debug email.

🤖 Generated with [Claude Code](https://claude.com/claude-code)