### PR TITLE
Azure debug: Drop log level from DEBUG to INFO

### DIFF
--- a/clouddump/job_azure.py
+++ b/clouddump/job_azure.py
@@ -70,11 +70,10 @@ def run_az_sync(blobstorage, logfile_path):
     cmd = ["azcopy", "sync", f"--delete-destination={'true' if delete else 'false'}"]
     if clouddump.debug:
         # Azcopy log levels: DEBUG (detailed trace, firehose) | INFO (every
-        # request/response — a line per blob on 100k+ containers) |
-        # WARNING (slow responses + errors) | ERROR | NONE.
-        # WARNING hits the useful middle: the sidecar is small on happy runs
-        # but still surfaces what went wrong when something breaks.
-        cmd += ["--log-level=WARNING"]
+        # request/response — a line per blob) | WARNING | ERROR | NONE.
+        # INFO keeps per-request visibility for the email sidecar without the
+        # full HTTP body trace DEBUG produces.
+        cmd += ["--log-level=INFO"]
     cmd += [source, destination]
 
     t0 = time.time()

--- a/clouddump/job_azure.py
+++ b/clouddump/job_azure.py
@@ -69,10 +69,12 @@ def run_az_sync(blobstorage, logfile_path):
 
     cmd = ["azcopy", "sync", f"--delete-destination={'true' if delete else 'false'}"]
     if clouddump.debug:
-        # azcopy's --output-level only supports essential/quiet/default — there
-        # is no verbose stdout mode. HTTP-level detail goes to the per-job
-        # log file under ~/.azcopy/<uuid>.log when --log-level=DEBUG is set.
-        cmd += ["--log-level=DEBUG"]
+        # Azcopy log levels: DEBUG (detailed trace, firehose) | INFO (every
+        # request/response — a line per blob on 100k+ containers) |
+        # WARNING (slow responses + errors) | ERROR | NONE.
+        # WARNING hits the useful middle: the sidecar is small on happy runs
+        # but still surfaces what went wrong when something breaks.
+        cmd += ["--log-level=WARNING"]
     cmd += [source, destination]
 
     t0 = time.time()

--- a/tests/test_runners.py
+++ b/tests/test_runners.py
@@ -181,8 +181,8 @@ class TestAzureRunner:
         run_az_sync(self._cfg(destination=dest), _tmp_logfile)
 
         cmd = calls[0][0]
-        # WARNING is the middle ground — DEBUG was a firehose on 100k+ blobs.
-        assert "--log-level=WARNING" in cmd
+        # INFO keeps per-request lines without the full HTTP trace DEBUG adds.
+        assert "--log-level=INFO" in cmd
         # --output-level only accepts essential/quiet/default — no verbose.
         assert not any(a.startswith("--output-level") for a in cmd)
 

--- a/tests/test_runners.py
+++ b/tests/test_runners.py
@@ -181,7 +181,8 @@ class TestAzureRunner:
         run_az_sync(self._cfg(destination=dest), _tmp_logfile)
 
         cmd = calls[0][0]
-        assert "--log-level=DEBUG" in cmd
+        # WARNING is the middle ground — DEBUG was a firehose on 100k+ blobs.
+        assert "--log-level=WARNING" in cmd
         # --output-level only accepts essential/quiet/default — no verbose.
         assert not any(a.startswith("--output-level") for a in cmd)
 


### PR DESCRIPTION
## Summary

\`--log-level=DEBUG\` made azcopy's per-invocation log a firehose — a full HTTP-body trace per request for containers with 100k+ blobs. The sidecar attached to the job email was unreadably large on \`cylinder\`.

Azcopy log levels:
- \`DEBUG\` — full trace incl. HTTP bodies (what we had)
- \`INFO\` — every request/response, one line per blob
- \`WARNING\` — slow responses + errors only
- \`ERROR\` — failed requests only
- \`NONE\`

Switching to \`INFO\`. Keeps per-request visibility in the email sidecar so you can still see what azcopy actually did, just without the full HTTP bodies. WARNING was considered but leaves happy runs with a near-empty sidecar — defeats the point of attaching it.

## Test plan
- [x] \`pytest tests/test_runners.py\` — 79 passed
- [ ] Deploy + trigger. The \`.azcopy.log\` sidecars on the job email should be substantially smaller than under v1.4.10 but still list every blob operation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)