### PR TITLE
Azure job: Prune ~/.azcopy logs to bound container disk use

### DIFF
--- a/clouddump/__main__.py
+++ b/clouddump/__main__.py
@@ -157,6 +157,9 @@ def main():
         log_requests=bool(cfg(config, "health_log", False)),
     )
 
+    from clouddump.job_azure import prune_stale_azcopy_logs
+    prune_stale_azcopy_logs()
+
     # Main loop
     log.info("Starting main loop...")
     last_run_ts = 0

--- a/clouddump/job_azure.py
+++ b/clouddump/job_azure.py
@@ -5,29 +5,33 @@ import re
 import time
 
 import clouddump
-from clouddump import cfg, log, redact, run_cmd
+from clouddump import cfg, log, redact, run_cmd, _safe_remove
 
 _AZCOPY_JOB_LOG_DIR = os.path.expanduser("~/.azcopy")
 _SAFE_NAME_RE = re.compile(r"[^A-Za-z0-9_.-]")
+_AZCOPY_STALE_SECONDS = 7 * 24 * 60 * 60
+
+
+def _list_azcopy_logs():
+    try:
+        return [
+            os.path.join(_AZCOPY_JOB_LOG_DIR, f)
+            for f in os.listdir(_AZCOPY_JOB_LOG_DIR)
+            if f.endswith(".log")
+        ]
+    except FileNotFoundError:
+        return []
 
 
 def _copy_azcopy_job_log(sidecar_path):
     """Copy the most recent azcopy per-job log to *sidecar_path*, redacted.
 
-    Azcopy writes a separate `<uuid>.log` in ``~/.azcopy/`` per invocation
-    with the HTTP-level detail requested by ``--log-level=DEBUG``. Its
-    stdout only shows the progress summary. When debug is on we copy that
-    per-job log to a sidecar file next to the attempt's logfile so
-    ``send_job_report`` picks it up as its own email attachment.
+    After copying, remove the azcopy-side log(s) for that invocation so
+    ``~/.azcopy/`` doesn't accumulate across runs inside a long-lived
+    container. If the copy fails, leave the source in place so the user
+    can inspect it directly.
     """
-    try:
-        logs = [
-            os.path.join(_AZCOPY_JOB_LOG_DIR, f)
-            for f in os.listdir(_AZCOPY_JOB_LOG_DIR)
-            if f.endswith(".log") and not f.endswith("-scanning.log")
-        ]
-    except FileNotFoundError:
-        return
+    logs = [p for p in _list_azcopy_logs() if not p.endswith("-scanning.log")]
     if not logs:
         return
     newest = max(logs, key=os.path.getmtime)
@@ -38,6 +42,34 @@ def _copy_azcopy_job_log(sidecar_path):
                 dst.write(redact(line))
     except OSError as exc:
         log.warning("Could not copy azcopy job log %s: %s", newest, exc)
+        return
+
+    # Source copied safely — drop the invocation's logs. Each azcopy run
+    # writes <uuid>.log plus an optional <uuid>-scanning.log; clean up both.
+    _safe_remove(newest)
+    scanning = newest[:-len(".log")] + "-scanning.log"
+    _safe_remove(scanning)
+
+
+def prune_stale_azcopy_logs(max_age_seconds=_AZCOPY_STALE_SECONDS):
+    """Remove ``~/.azcopy/*.log`` files older than *max_age_seconds*.
+
+    Intended to run at startup to clean up logs left behind by previous
+    container incarnations or runs that crashed before the per-invocation
+    cleanup in :func:`_copy_azcopy_job_log` could fire.
+    """
+    now = time.time()
+    removed = 0
+    for path in _list_azcopy_logs():
+        try:
+            if now - os.path.getmtime(path) > max_age_seconds:
+                _safe_remove(path)
+                removed += 1
+        except OSError:
+            pass
+    if removed:
+        log.info("Pruned %d stale azcopy log file(s) from %s",
+                 removed, _AZCOPY_JOB_LOG_DIR)
 
 
 def _container_from_source(source):

--- a/tests/test_runners.py
+++ b/tests/test_runners.py
@@ -215,6 +215,57 @@ class TestAzureRunner:
         main = open(_tmp_logfile, encoding="utf-8").read()
         assert "RESPONSE 200" not in main
 
+    def test_debug_prunes_azcopy_source_after_copy(self, monkeypatch, tmp_path, _tmp_logfile):
+        """Source log + scanning sibling are removed once copied to sidecar."""
+        import clouddump
+        from clouddump import job_azure
+        from clouddump.job_azure import run_az_sync
+
+        dest = str(tmp_path / "azout")
+        open(_tmp_logfile, "w").close()
+        azcopy_log_dir = tmp_path / "azcopy"
+        azcopy_log_dir.mkdir()
+        uuid = "11111111-2222-3333-4444-555555555555"
+        job_log = azcopy_log_dir / f"{uuid}.log"
+        job_log.write_text("RESPONSE 200\n")
+        scanning_log = azcopy_log_dir / f"{uuid}-scanning.log"
+        scanning_log.write_text("scanning...\n")
+        monkeypatch.setattr(job_azure, "_AZCOPY_JOB_LOG_DIR", str(azcopy_log_dir))
+        _capture_cmd(monkeypatch, "clouddump.job_azure.run_cmd")
+        monkeypatch.setattr(clouddump, "debug", True)
+
+        run_az_sync(self._cfg(destination=dest), _tmp_logfile)
+
+        assert not job_log.exists()
+        assert not scanning_log.exists()
+
+    def test_prune_stale_azcopy_logs(self, tmp_path, monkeypatch):
+        """Startup prune removes logs older than max_age; keeps recent ones."""
+        import os
+        import time
+        from clouddump import job_azure
+
+        azcopy_log_dir = tmp_path / "azcopy"
+        azcopy_log_dir.mkdir()
+        old_log = azcopy_log_dir / "old.log"
+        old_log.write_text("stale\n")
+        recent_log = azcopy_log_dir / "recent.log"
+        recent_log.write_text("fresh\n")
+        unrelated = azcopy_log_dir / "notes.txt"
+        unrelated.write_text("ignore\n")
+
+        old_mtime = time.time() - 10 * 24 * 60 * 60
+        os.utime(old_log, (old_mtime, old_mtime))
+        os.utime(unrelated, (old_mtime, old_mtime))
+        monkeypatch.setattr(job_azure, "_AZCOPY_JOB_LOG_DIR", str(azcopy_log_dir))
+
+        job_azure.prune_stale_azcopy_logs(max_age_seconds=7 * 24 * 60 * 60)
+
+        assert not old_log.exists()
+        assert recent_log.exists()
+        # Non-*.log files are left alone.
+        assert unrelated.exists()
+
     def test_no_debug_flags_by_default(self, monkeypatch, tmp_path, _tmp_logfile):
         import clouddump
         from clouddump.job_azure import run_az_sync


### PR DESCRIPTION
## Summary

Azcopy writes a per-invocation log to \`~/.azcopy/<uuid>.log\`. We already copy that into a sidecar for email (#228), but the original was left behind. Inside a long-lived container every azcopy run silently accumulated a log file — across daily schedules with 6+ blobstorages this grows without bound until the container is recreated. The container is ephemeral, so anything living only in its filesystem is hidden state that shouldn't be there.

Two changes:

- **Per-invocation cleanup** — once \`_copy_azcopy_job_log\` has redacted the source into the sidecar, remove the source \`<uuid>.log\` and its \`<uuid>-scanning.log\` sibling. If the copy fails, the source is left in place so you can inspect it directly via SSH (the sidecar may be missing/incomplete).
- **Startup prune** — \`prune_stale_azcopy_logs()\` runs once before the main loop and removes any \`~/.azcopy/*.log\` older than 7 days. Catches logs left behind by container incarnations before this change, and runs that crashed before per-invocation cleanup could fire.

## Test plan
- [x] \`pytest tests/\` — 210 passed, 7 skipped. Two new tests:
  - \`test_debug_prunes_azcopy_source_after_copy\` — UUID pair removed after successful copy.
  - \`test_prune_stale_azcopy_logs\` — age cutoff honored, non-\`*.log\` files left alone.
- [ ] Deploy + trigger. After a sync, \`docker exec clouddump ls ~/.azcopy/\` should be empty (container lifetime).

🤖 Generated with [Claude Code](https://claude.com/claude-code)