### PR TITLE
Pgsql cleanup: Remove orphaned temp dump files at job start

### DIFF
--- a/clouddump/job_pgsql.py
+++ b/clouddump/job_pgsql.py
@@ -1,6 +1,7 @@
 """PostgreSQL dump job runner."""
 
 import os
+import re
 import shutil
 import subprocess
 import time
@@ -11,6 +12,12 @@ from clouddump import cfg, fmt_bytes, log, run_cmd, _safe_remove
 
 # Databases that should never be dumped.
 _SYSTEM_DATABASES = {"template0", "template1", "postgres"}
+
+# Temp dump files during a run match `{database}-{14-digit-UTC-timestamp}.dump`.
+# Successful dumps get renamed to `{database}.dump[.bz2]`, so anything matching
+# this pattern on disk is a leftover from a process that died (OOM, container
+# restart, host reboot) before the retry-loop's own cleanup could run.
+_TEMP_FILE_RE = re.compile(r"^.+-\d{14}\.dump$")
 
 # Azure PG silently drops idle connections; these detect dead sockets in ~80s
 # instead of Linux's 2h tcp_keepalive_time default.
@@ -26,6 +33,18 @@ def _conninfo(host, port, user, dbname):
     parts = [f"host={host}", f"port={port}", f"user={user}", f"dbname={dbname}"]
     parts.extend(f"{k}={v}" for k, v in _KEEPALIVE_OPTS.items())
     return " ".join(parts)
+
+
+def _cleanup_stale_temps(backuppath):
+    try:
+        entries = os.listdir(backuppath)
+    except OSError:
+        return
+    for name in entries:
+        if _TEMP_FILE_RE.match(name):
+            path = os.path.join(backuppath, name)
+            log.warning("Removing stale temp dump from prior crashed run: %s", name)
+            _safe_remove(path)
 
 
 def _list_databases(host, port, user, password):
@@ -79,6 +98,7 @@ def run_pg_dump(server, logfile_path):
         return 1
 
     os.makedirs(backuppath, exist_ok=True)
+    _cleanup_stale_temps(backuppath)
 
     log.info("Dumping PostgreSQL server", extra={"host": host, "port": int(port), "destination": backuppath})
     log.debug("Username: %s, filenamedate: %s, compress: %s", user, filenamedate, compress)

--- a/tests/test_runners.py
+++ b/tests/test_runners.py
@@ -376,6 +376,31 @@ class TestPgSQLRunner:
         assert rc == 0
         assert any(r.levelno == logging.WARNING and "No databases to backup" in r.message for r in caplog.records)
 
+    def test_cleanup_stale_temps_removes_orphans_and_preserves_finals(self, tmp_path):
+        from clouddump.job_pgsql import _cleanup_stale_temps
+
+        # Orphans (timestamped temp files from prior crashed runs)
+        (tmp_path / "db1-20240101000000.dump").write_bytes(b"partial")
+        (tmp_path / "db2-20240102000000.dump").write_bytes(b"partial")
+
+        # Final dumps (must be preserved)
+        (tmp_path / "db1.dump.bz2").write_bytes(b"final")
+        (tmp_path / "db1.dump").write_bytes(b"final")
+
+        # Unrelated files (must be preserved)
+        (tmp_path / "readme.txt").write_bytes(b"x")
+        (tmp_path / "report.log").write_bytes(b"x")
+
+        _cleanup_stale_temps(str(tmp_path))
+
+        remaining = sorted(p.name for p in tmp_path.iterdir())
+        assert remaining == ["db1.dump", "db1.dump.bz2", "readme.txt", "report.log"]
+
+    def test_cleanup_stale_temps_missing_dir_is_noop(self, tmp_path):
+        from clouddump.job_pgsql import _cleanup_stale_temps
+
+        _cleanup_stale_temps(str(tmp_path / "does-not-exist"))  # must not raise
+
 
 # ── MySQL runner ────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Problem

When `pg_dump` is killed without returning cleanly (OOM, container restart, host reboot, `SIGKILL`), the retry loop's own `_safe_remove(temp_file)` never runs. The timestamped temp file (`{database}-{timestamp}.dump`) is left on disk. Over time this accumulates partial dumps on the backup share.

The in-loop retry cleanup still handles ordinary failures (non-zero exit, empty output) — it just can't cover cases where the interpreter itself doesn't get to run its finally/cleanup path.

## Change

Add a single-pass cleanup at the start of `run_pg_dump`: scan `backuppath` and remove any file matching `^.+-\d{14}\.dump$`. Successful dumps are renamed to `{database}.dump[.bz2]`, so any file with the 14-digit-timestamp suffix is by definition a leftover from a crashed prior run.

- Only removes files matching the exact timestamped naming pattern — final dumps (`*.dump.bz2`, `*.dump` without timestamp), unrelated files, and subdirectories are untouched.
- Missing `backuppath` is a no-op (returns cleanly instead of raising).
- Logs each removal at WARNING so the next run makes the crash visible in logs.

## Test plan
- [x] New unit tests: removes timestamped orphans, preserves finals and unrelated files, no-ops on missing dir.
- [x] `pytest tests/test_runners.py tests/test_unit.py` — 212 passed, 7 skipped.
- [x] `ruff check clouddump tests` — clean.