### PR TITLE
email: cap attachment size (gzip→drop w/ visible warning) + log send result; rsync: delete_excluded

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 __pycache__/
 .claude/
 *.exe.stackdump
+
+# pytest coverage
+.coverage

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -30,6 +30,7 @@ All settings are top-level keys in `config.json`, alongside `jobs`.
 | `mail_from` | No | Sender address (e.g. `"backup@example.com"` or `"CloudDump <backup@example.com>"`) |
 | `mail_to` | No | Recipient address(es) — comma-separated or JSON array |
 | `email_log_attached` | No | Attach full log file to job report emails (`true`/`false`, default `false`) |
+| `email_size_limit_mb` | No | Max email size (MB, default `15`). Over this, attachments are gzipped individually; if still over, they are dropped and an error is logged. The report body always sends. |
 | `crontab` | **Yes** | Standard 5-field cron expression — schedule for running all jobs |
 | `health_port` | No | Port for the HTTP health endpoint (`1`–`65535`, default `8080`) |
 | `health_log` | No | Log health-check HTTP requests at DEBUG level (`true`/`false`, default `false`) |
@@ -244,6 +245,7 @@ By default only repository code is backed up. Metadata options (issues, pulls, l
       "ssh_key": "/config/id_ed25519",
       "ssh_port": 22,
       "delete_destination": true,
+      "delete_excluded": false,
       "exclude": ["*.tmp", "cache/"],
       "min_age_days": 30
     }
@@ -257,6 +259,7 @@ By default only repository code is backed up. Metadata options (issues, pulls, l
 - `ssh_port`: SSH port (default: `22`).
 - `delete_destination`: remove files at destination that no longer exist at source (default: `true`). When combined with `min_age_days`, the destination becomes an exact mirror of the filtered file set: any destination file that is **not** in the age-filtered list is removed. This means files newer than `min_age_days` will **not** be present at the destination. Set `delete_destination` to `false` if you want to accumulate old files while keeping previously synced files intact.
 - `exclude`: list of rsync exclude patterns (default: none).
+- `delete_excluded`: also delete `exclude`d paths from the destination (default: `false`). Implies deletion (`--delete`), so already-mirrored copies of newly-excluded paths (e.g. regenerable caches) are purged on the next run. Without this, excluded paths already present at the destination are left untouched.
 - `min_age_days`: only copy files whose modification time is older than this many days (default: none — copy all files). When set, CloudDump enumerates remote files via `rsync --list-only`, filters by mtime client-side, and passes the qualifying paths to the main rsync with `--files-from`. Uses the rsync protocol only — no remote shell commands — so it works with restricted SSH accounts (forced commands, `rrsync`, etc.).
 
 The SSH key file should be mounted read-only into the container:

--- a/README.md
+++ b/README.md
@@ -222,6 +222,14 @@ Set `"smtp_security": "starttls"` for port 587, or `"smtp_security": "none"` for
 plain SMTP relays. Verify the container can reach your SMTP server. Check logs
 for `Failed to send email` messages.
 
+**Report arrives without its log attachment** — the email exceeded
+`email_size_limit_mb` (default 15 MB) even after gzip, so attachments were
+dropped to keep the report deliverable; the log line says so at `error` level.
+Some providers (e.g. Mailgun) accept oversized messages at SMTP but silently
+fail to deliver them, so this guard keeps reports flowing. Raise
+`email_size_limit_mb`, set `email_log_attached: false`, or trim the job's log
+volume (e.g. rsync `exclude`s) if you need the attachment.
+
 **Run jobs now** — Send `SIGUSR1` to run all jobs immediately without waiting
 for the cron schedule:
 

--- a/clouddump/config.py
+++ b/clouddump/config.py
@@ -82,6 +82,15 @@ def validate_settings(config):
             log.error("Invalid health_port '%s': %s.", health_port, exc)
             errors += 1
 
+    size_limit = config.get("email_size_limit_mb")
+    if size_limit is not None:
+        try:
+            if int(size_limit) <= 0:
+                raise ValueError("must be positive")
+        except (ValueError, TypeError) as exc:
+            log.error("Invalid email_size_limit_mb '%s': %s.", size_limit, exc)
+            errors += 1
+
     return errors
 
 
@@ -153,7 +162,7 @@ def validate_jobs(jobs):
                 "include_labels", "include_milestones", "include_releases",
                 "include_wikis", "include_forks", "include_archived", "include_lfs",
             ]),
-            "rsync": ("targets", ["delete_destination"]),
+            "rsync": ("targets", ["delete_destination", "delete_excluded"]),
         }
         _TARGET_INTS = {
             "pgsql": ("servers", ["port", "db_retries"]),

--- a/clouddump/email.py
+++ b/clouddump/email.py
@@ -1,5 +1,6 @@
 """Email reporting and notification."""
 
+import gzip
 import json
 import os
 import smtplib
@@ -8,7 +9,10 @@ from email.mime.application import MIMEApplication
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 
-from clouddump import cfg, log, redact
+from clouddump import cfg, fmt_bytes, log, redact
+
+
+DEFAULT_EMAIL_SIZE_LIMIT_MB = 15
 
 
 def _resolve_smtp_security(config):
@@ -18,6 +22,69 @@ def _resolve_smtp_security(config):
     ``"none"``).  Default is ``"ssl"``.
     """
     return cfg(config, "smtp_security") or "ssl"
+
+
+def _build_message(mail_from, recipients, subject, body, parts):
+    """Assemble a MIMEMultipart message from prepared attachment parts.
+
+    *parts* is a list of ``(filename, payload_bytes)`` tuples; each is
+    attached as a base64-encoded MIMEApplication.
+    """
+    msg = MIMEMultipart()
+    msg["From"] = mail_from
+    msg["To"] = ", ".join(recipients)
+    msg["Subject"] = subject
+    msg.attach(MIMEText(body, "plain"))
+    for filename, payload in parts:
+        part = MIMEApplication(payload, Name=filename)
+        part["Content-Disposition"] = f'attachment; filename="{filename}"'
+        msg.attach(part)
+    return msg
+
+
+def _enforce_size_limit(config, mail_from, recipients, subject, body, raw_parts):
+    """Build the message, keeping it under ``email_size_limit_mb``.
+
+    The size is measured on the assembled, base64-encoded message — i.e. what
+    the SMTP server actually receives. Staged fallback when it exceeds the
+    limit:
+
+    1. gzip each attachment individually;
+    2. if still over, drop all attachments and log an error.
+
+    The report body is always sent — only attachments are compressed or
+    dropped, so the job is never silently un-reported.
+    """
+    try:
+        limit_mb = int(cfg(config, "email_size_limit_mb", DEFAULT_EMAIL_SIZE_LIMIT_MB))
+    except (ValueError, TypeError):
+        limit_mb = DEFAULT_EMAIL_SIZE_LIMIT_MB
+    limit = limit_mb * 1024 * 1024
+
+    msg = _build_message(mail_from, recipients, subject, body, raw_parts)
+    if not raw_parts or len(msg.as_bytes()) <= limit:
+        return msg
+
+    # Stage 1: compress each attachment individually.
+    gz_parts = [(f"{name}.gz", gzip.compress(payload)) for name, payload in raw_parts]
+    msg = _build_message(mail_from, recipients, subject, body, gz_parts)
+    if len(msg.as_bytes()) <= limit:
+        log.info("Email attachments exceeded %d MB; compressed to fit.", limit_mb)
+        return msg
+
+    # Stage 2: still too large — drop attachments, but make the omission
+    # explicit in the body so the report never hides that a log is missing.
+    log.error(
+        "Email attachments exceed the %d MB limit even after compression; "
+        "sending report without attachments.", limit_mb,
+    )
+    notice = (
+        f"WARNING: log attachment(s) omitted — exceeded the {limit_mb} MB email "
+        f"size limit even after compression. Retrieve the full log from the "
+        f"container/host logs.\n\n"
+        f"{'-' * 60}\n\n"
+    )
+    return _build_message(mail_from, recipients, subject, notice + body, [])
 
 
 def send_email(config, subject, body, attachments=None):
@@ -59,12 +126,9 @@ def send_email(config, subject, body, attachments=None):
     else:
         recipients = [r.strip() for r in mail_to.split(",") if r.strip()]
 
-    msg = MIMEMultipart()
-    msg["From"] = mail_from
-    msg["To"] = ", ".join(recipients)
-    msg["Subject"] = subject
-    msg.attach(MIMEText(body, "plain"))
-
+    # Read + redact attachment contents into memory so the final message size
+    # can be measured and, if needed, compressed or dropped before sending.
+    raw_parts = []  # (filename, payload_bytes)
     for entry in attachments or []:
         if isinstance(entry, tuple):
             path, name = entry
@@ -73,9 +137,9 @@ def send_email(config, subject, body, attachments=None):
         if os.path.isfile(path):
             with open(path, "r") as f:
                 content = redact(f.read())
-            part = MIMEApplication(content.encode("utf-8"), Name=name)
-            part["Content-Disposition"] = f'attachment; filename="{name}"'
-            msg.attach(part)
+            raw_parts.append((name, content.encode("utf-8")))
+
+    msg = _enforce_size_limit(config, mail_from, recipients, subject, body, raw_parts)
 
     log.info("Sending email to %s from %s.", ", ".join(recipients), mail_from)
     try:
@@ -92,6 +156,7 @@ def send_email(config, subject, body, attachments=None):
     except Exception as exc:
         log.error("Failed to send email: %s", exc, exc_info=True)
         return False
+    log.debug("Email sent to %s (%s).", ", ".join(recipients), fmt_bytes(len(msg.as_bytes())))
     return True
 
 
@@ -168,4 +233,5 @@ def send_job_report(config, version, host, job, exit_code, t_start, t_end, logfi
                     attachments.append((sidecar, name))
 
     subject = f"[{status}] CloudDump {host}: {job_id}"
-    send_email(config, subject, body, attachments)
+    if send_email(config, subject, body, attachments) is False:
+        log.error("Job report email for %s could not be sent.", job_id)

--- a/clouddump/job_rsync.py
+++ b/clouddump/job_rsync.py
@@ -68,6 +68,7 @@ def run_rsync_sync(target, logfile_path):
     ssh_key = cfg(target, "ssh_key")
     ssh_port = str(cfg(target, "ssh_port", "22"))
     delete = cfg(target, "delete_destination", True)
+    delete_excluded = cfg(target, "delete_excluded", False)
     exclude = cfg(target, "exclude", [])
     min_age_days = cfg(target, "min_age_days")
 
@@ -116,8 +117,12 @@ def run_rsync_sync(target, logfile_path):
         cmd += ["-e", ssh_cmd]
         if filelist_path:
             cmd += ["--files-from", filelist_path]
-        if delete:
+        if delete or delete_excluded:
             cmd.append("--delete")
+        if delete_excluded:
+            # Also purge already-mirrored copies of newly-excluded paths
+            # (e.g. regenerable Nextcloud previews) from the destination.
+            cmd.append("--delete-excluded")
         for pattern in exclude:
             cmd += ["--exclude", pattern]
         cmd += [source, destination]

--- a/config.schema.json
+++ b/config.schema.json
@@ -64,6 +64,12 @@
       "default": false,
       "description": "Attach log file to job report emails."
     },
+    "email_size_limit_mb": {
+      "type": "integer",
+      "minimum": 1,
+      "default": 15,
+      "description": "Max email size in MB. Over this, attachments are gzipped individually; if still over, they are dropped and an error is logged. The report body always sends."
+    },
     "jobs": {
       "type": "array",
       "minItems": 1,
@@ -176,6 +182,7 @@
         "ssh_key": { "type": "string", "description": "Path to SSH private key." },
         "ssh_port": { "type": "integer", "default": 22 },
         "delete_destination": { "type": "boolean", "default": true },
+        "delete_excluded": { "type": "boolean", "default": false, "description": "Also delete excluded paths from the destination (implies --delete). Purges already-mirrored copies of newly-excluded paths." },
         "exclude": { "type": "array", "items": { "type": "string" }, "description": "Rsync exclude patterns." },
         "min_age_days": { "type": "integer", "minimum": 1, "description": "Only sync files older than N days." }
       },

--- a/tests/test_runners.py
+++ b/tests/test_runners.py
@@ -940,6 +940,30 @@ class TestRsyncRunner:
         idx2 = cmd.index("--exclude", idx1 + 1)
         assert cmd[idx2 + 1] == "cache/"
 
+    def test_delete_excluded(self, monkeypatch, tmp_path, _tmp_logfile):
+        from clouddump.job_rsync import run_rsync_sync
+
+        dest = str(tmp_path / "rsyncout")
+        calls = _capture_cmd(monkeypatch, "clouddump.job_rsync.run_cmd")
+
+        run_rsync_sync(self._cfg(destination=dest, delete_excluded=True,
+                                 exclude=["preview/"]), _tmp_logfile)
+
+        cmd = calls[0][0]
+        # --delete-excluded implies deletion, so --delete must also be present
+        assert "--delete" in cmd
+        assert "--delete-excluded" in cmd
+
+    def test_delete_excluded_off_by_default(self, monkeypatch, tmp_path, _tmp_logfile):
+        from clouddump.job_rsync import run_rsync_sync
+
+        dest = str(tmp_path / "rsyncout")
+        calls = _capture_cmd(monkeypatch, "clouddump.job_rsync.run_cmd")
+
+        run_rsync_sync(self._cfg(destination=dest, exclude=["preview/"]), _tmp_logfile)
+
+        assert "--delete-excluded" not in calls[0][0]
+
     def test_missing_source(self, monkeypatch, _tmp_logfile):
         from clouddump.job_rsync import run_rsync_sync
 

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -2,6 +2,7 @@
 
 import json
 import logging
+import os
 import sys
 from datetime import datetime, timezone
 from unittest.mock import patch
@@ -11,7 +12,7 @@ import urllib.request
 import pytest
 
 from clouddump import redact, fmt_bytes, validate_backup_path, _TextFormatter, _JsonFormatter, _LOG_FORMAT, _LOG_DATEFMT
-from clouddump.email import format_job_config
+from clouddump.email import format_job_config, send_email, _enforce_size_limit
 from clouddump.config import validate_settings, validate_jobs, verify_connectivity
 from clouddump.cron import matches_cron, should_run, validate_cron
 from clouddump.health import _state, update_last_run, update_job_metric, _Handler
@@ -865,3 +866,98 @@ def test_healthz_404_on_other_paths():
             assert exc.code == 404
     finally:
         server.shutdown()
+
+
+# ── email: attachment size limit ─────────────────────────────────────────────
+
+
+def _attachment_names(msg):
+    """Filenames of all attachment parts in a built message."""
+    return [p.get_filename() for p in msg.get_payload() if p.get_filename()]
+
+
+def test_enforce_size_limit_passthrough():
+    parts = [("report.log", b"a small log line\n")]
+    msg = _enforce_size_limit({}, "from@x", ["to@x"], "subj", "body", parts)
+    assert _attachment_names(msg) == ["report.log"]
+
+
+def test_enforce_size_limit_compresses_when_over():
+    # 2 MB of highly compressible text, 1 MB limit → gzip brings it under.
+    parts = [("big.log", b"X" * (2 * 1024 * 1024))]
+    msg = _enforce_size_limit({"email_size_limit_mb": 1}, "from@x", ["to@x"],
+                              "subj", "body", parts)
+    assert _attachment_names(msg) == ["big.log.gz"]
+
+
+def test_enforce_size_limit_drops_when_incompressible(caplog):
+    # 3 MB of incompressible bytes, 1 MB limit → gzip can't help → dropped.
+    parts = [("big.log", os.urandom(3 * 1024 * 1024))]
+    with caplog.at_level(logging.ERROR, logger="clouddump"):
+        msg = _enforce_size_limit({"email_size_limit_mb": 1}, "from@x", ["to@x"],
+                                  "subj", "report body", parts)
+    assert _attachment_names(msg) == []
+    assert any("without attachments" in r.getMessage() for r in caplog.records)
+    # The omission must be visible in the email body, not just the logs.
+    body_text = msg.get_payload()[0].get_payload(decode=True).decode("utf-8")
+    assert "WARNING" in body_text and "omitted" in body_text
+    assert "report body" in body_text  # original body is preserved
+
+
+# ── email: send result ───────────────────────────────────────────────────────
+
+
+class _FakeSMTP:
+    """Minimal smtplib.SMTP_SSL stand-in capturing sendmail calls."""
+
+    last = None
+
+    def __init__(self, *a, **k):
+        self.sent = []
+        _FakeSMTP.last = self
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+    def login(self, *a, **k):
+        pass
+
+    def sendmail(self, mail_from, recipients, msg):
+        self.sent.append((mail_from, recipients, msg))
+
+
+def _smtp_config(**over):
+    config = {
+        "smtp_server": "smtp.example.com",
+        "smtp_port": 465,
+        "smtp_security": "ssl",
+        "mail_from": "from@example.com",
+        "mail_to": "to@example.com",
+    }
+    config.update(over)
+    return config
+
+
+def test_send_email_success_returns_true():
+    with patch("clouddump.email.smtplib.SMTP_SSL", _FakeSMTP):
+        result = send_email(_smtp_config(), "subj", "body")
+    assert result is True
+    assert _FakeSMTP.last.sent  # sendmail was called
+
+
+def test_send_email_failure_returns_false(caplog):
+    def _boom(*a, **k):
+        raise OSError("connection refused")
+
+    with patch("clouddump.email.smtplib.SMTP_SSL", _boom):
+        with caplog.at_level(logging.ERROR, logger="clouddump"):
+            result = send_email(_smtp_config(), "subj", "body")
+    assert result is False
+    assert any("Failed to send email" in r.getMessage() for r in caplog.records)
+
+
+def test_send_email_not_configured_returns_none():
+    assert send_email({}, "subj", "body") is None


### PR DESCRIPTION
## Why

Some SMTP providers (e.g. Mailgun) **accept** an oversized message at the SMTP layer but then silently fail to deliver it. CloudDump logged "success" because the relay accepted, so a job report with a large log attachment vanished with no visible error. (Observed in production: a ~95 MB debug `rsync -v` log attachment made the Nextcloud backup report undeliverable for days while CloudDump reported success.)

## Changes

**`email.py` — bounded, never-silent attachments**
- New top-level `email_size_limit_mb` (default **15**). The message size is measured on the assembled, **base64-encoded** message — i.e. what the SMTP server actually receives.
- If over the limit: **gzip each attachment individually**. Log lists compress ~20–30×.
- If still over: **drop all attachments** and prepend a **`WARNING:` banner to the email body** so the omission is visible in the report itself, not just the logs.
- The report body always sends → a job is never silently un-reported.
- `send_job_report` now checks `send_email`'s return value and logs an error if the report could not be sent; `send_email` logs successful delivery at debug level.

**`job_rsync.py` — `delete_excluded`**
- New per-target `delete_excluded` flag → `rsync --delete-excluded` (implies `--delete`). Lets a mirror purge already-copied excluded paths (e.g. regenerable Nextcloud previews/caches) on the next run, instead of leaving them orphaned forever.

**Docs/validation:** `config.py` validation (`email_size_limit_mb`, `delete_excluded`), `config.schema.json`, `CONFIGURATION.md`, `README.md`.

## Tests

`tests/test_unit.py`: passthrough / gzip-to-fit / drop-with-warning-banner; `send_email` returns True/False/None correctly. `tests/test_runners.py`: rsync emits `--delete-excluded` (and not by default). Full suite: 220 passed, 7 skipped; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
