### PR TITLE
Dockerfile: install azcopy from static binary (unblocks Debian 13 bump)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,13 +25,11 @@ RUN apt-get update && \
     rsync \
     awscli \
     procps \
-    && . /etc/os-release \
-    && curl -sSL -o /tmp/packages-microsoft-prod.deb "https://packages.microsoft.com/config/debian/${VERSION_ID}/packages-microsoft-prod.deb" \
-    && dpkg -i /tmp/packages-microsoft-prod.deb \
-    && rm /tmp/packages-microsoft-prod.deb \
-    && apt-get update \
-    && apt-get install -y --no-install-recommends azcopy \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/* \
+    && curl -sSL -o /tmp/azcopy.tar.gz https://aka.ms/downloadazcopy-v10-linux \
+    && tar -xzf /tmp/azcopy.tar.gz -C /tmp \
+    && install -m 0755 /tmp/azcopy_linux_amd64_*/azcopy /usr/local/bin/azcopy \
+    && rm -rf /tmp/azcopy.tar.gz /tmp/azcopy_linux_amd64_*
 
 COPY requirements.txt /tmp/requirements.txt
 RUN pip install --no-cache-dir --break-system-packages -r /tmp/requirements.txt \


### PR DESCRIPTION
## Why

The Debian base-image bump 12→13 (#235) fails CI on Docker build + integration:

```
E: Unable to locate package azcopy
```

Microsoft's apt repo has a `debian/13` (trixie) feed, but **azcopy isn't published there** (only in `debian/12`/bookworm). azcopy is the only consumer of the MS apt repo in the Dockerfile.

## Change

Install the static azcopy binary from `https://aka.ms/downloadazcopy-v10-linux` and drop the `packages-microsoft-prod.deb` + MS apt repo entirely. Debian-version independent, so it works on bookworm now and trixie later.

- `. /etc/os-release` is still sourced upstream for the PGDG repo; `VERSION_ID` is no longer referenced.
- This PR stays on `debian:12.13-slim`, so CI here proves the static install works on bookworm. The trixie bump (#235) rebases on top.

Closes #237. Unblocks #235.

🤖 Generated with [Claude Code](https://claude.com/claude-code)