### PR TITLE
Dockerfile: pin azcopy + add check-azcopy workflow for automated bumps

### DIFF
--- a/.github/workflows/check-azcopy.yaml
+++ b/.github/workflows/check-azcopy.yaml
@@ -1,0 +1,70 @@
+name: Check azcopy
+
+on:
+  schedule:
+    - cron: "0 7 * * 1" # weekly, Monday 07:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Bump pinned azcopy version if a newer release exists
+        id: bump
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          current=$(grep -oP 'ARG AZCOPY_VERSION=\K[0-9.]+' Dockerfile)
+          latest=$(gh api repos/Azure/azure-storage-azcopy/releases/latest --jq '.tag_name' | sed 's/^v//')
+          echo "current=$current latest=$latest"
+
+          if [ -z "$latest" ]; then
+            echo "Could not resolve latest azcopy release; skipping."
+            exit 0
+          fi
+          if [ "$current" = "$latest" ]; then
+            echo "Already on the latest azcopy ($current)."
+            exit 0
+          fi
+
+          # Only bump if the linux/amd64 asset actually exists for $latest.
+          url="https://github.com/Azure/azure-storage-azcopy/releases/download/v${latest}/azcopy_linux_amd64_${latest}.tar.gz"
+          if ! curl -fsIL "$url" >/dev/null 2>&1; then
+            echo "linux/amd64 asset not published for $latest yet; skipping."
+            exit 0
+          fi
+
+          sed -i "s/^ARG AZCOPY_VERSION=.*/ARG AZCOPY_VERSION=${latest}/" Dockerfile
+          {
+            echo "current=$current"
+            echo "latest=$latest"
+            echo "changed=true"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Open PR
+        if: steps.bump.outputs.changed == 'true'
+        uses: peter-evans/create-pull-request@v8
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: automated/azcopy-update
+          delete-branch: true
+          commit-message: "chore: bump azcopy to ${{ steps.bump.outputs.latest }}"
+          title: "chore: bump azcopy ${{ steps.bump.outputs.current }} → ${{ steps.bump.outputs.latest }}"
+          labels: dependencies
+          body: |
+            Bumps the pinned `AZCOPY_VERSION` in the Dockerfile.
+
+            - **${{ steps.bump.outputs.current }} → ${{ steps.bump.outputs.latest }}**
+            - Release: https://github.com/Azure/azure-storage-azcopy/releases/tag/v${{ steps.bump.outputs.latest }}
+
+            The Docker build + integration tests on this PR validate that the new
+            binary installs and azcopy still works. Review the release notes for
+            breaking changes (azstorage jobs) before merging.
+
+            Opened automatically by the `check-azcopy` workflow.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM debian:12.13-slim
 
+# Bumped by the check-azcopy workflow (PR on each new azcopy release).
+ARG AZCOPY_VERSION=10.32.4
+
 RUN apt-get update && \
     apt-get upgrade -y && \
     apt-get install -y --no-install-recommends \
@@ -26,10 +29,10 @@ RUN apt-get update && \
     awscli \
     procps \
     && rm -rf /var/lib/apt/lists/* \
-    && curl -sSL -o /tmp/azcopy.tar.gz https://aka.ms/downloadazcopy-v10-linux \
+    && curl -fsSL -o /tmp/azcopy.tar.gz "https://github.com/Azure/azure-storage-azcopy/releases/download/v${AZCOPY_VERSION}/azcopy_linux_amd64_${AZCOPY_VERSION}.tar.gz" \
     && tar -xzf /tmp/azcopy.tar.gz -C /tmp \
-    && install -m 0755 /tmp/azcopy_linux_amd64_*/azcopy /usr/local/bin/azcopy \
-    && rm -rf /tmp/azcopy.tar.gz /tmp/azcopy_linux_amd64_*
+    && install -m 0755 "/tmp/azcopy_linux_amd64_${AZCOPY_VERSION}/azcopy" /usr/local/bin/azcopy \
+    && rm -rf /tmp/azcopy.tar.gz "/tmp/azcopy_linux_amd64_${AZCOPY_VERSION}"
 
 COPY requirements.txt /tmp/requirements.txt
 RUN pip install --no-cache-dir --break-system-packages -r /tmp/requirements.txt \


### PR DESCRIPTION
## Why

After #238, azcopy installed from `aka.ms/...-latest` — **unpinned**: non-reproducible builds, no visibility into the installed version, and no CI gate (a bad azcopy release would ship silently on the next image build). `postgresql-client-18` is pinned and awscli has a `check-awscli` watcher; azcopy was the odd one out.

## Changes

- **Pin** via `ARG AZCOPY_VERSION=10.32.4`, downloading the versioned tarball from the [Azure/azure-storage-azcopy GitHub release](https://github.com/Azure/azure-storage-azcopy/releases) (clean, version-addressable URL).
- **`.github/workflows/check-azcopy.yaml`** (weekly Mon 07:00 UTC, matching `check-awscli`/`check-postgresql`): resolves the latest azcopy release, and if newer than the pin, opens a PR bumping `AZCOPY_VERSION`. The bump PR's **Docker build + integration tests** validate the new binary before merge.

So azcopy bumps are now automated *and* gated — no manual download, but every change is a reviewable, CI-checked PR.

## Validation

This PR's own CI builds the image with the pinned 10.32.4 from the GitHub release URL — confirming the pinned install path works end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)