### PR TITLE
check-azcopy: dispatch CI on auto-opened PRs

### DIFF
--- a/.github/workflows/check-azcopy.yaml
+++ b/.github/workflows/check-azcopy.yaml
@@ -8,6 +8,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  actions: write
 
 jobs:
   check:
@@ -48,6 +49,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Open PR
+        id: cpr
         if: steps.bump.outputs.changed == 'true'
         uses: peter-evans/create-pull-request@v8
         with:
@@ -68,3 +70,13 @@ jobs:
             breaking changes (azstorage jobs) before merging.
 
             Opened automatically by the `check-azcopy` workflow.
+
+      # PRs opened with GITHUB_TOKEN don't trigger pull_request workflows,
+      # so dispatch CI explicitly on the PR branch.
+      - name: Trigger CI on the PR branch
+        if: steps.bump.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh workflow run ci.yaml --ref automated/azcopy-update \
+            -f pr_number="${{ steps.cpr.outputs.pull-request-number }}"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,6 +3,13 @@ name: CI
 on:
   pull_request:
     branches: [main]
+  # Dispatched by check-azcopy on its PR branch: PRs opened with GITHUB_TOKEN
+  # never trigger pull_request workflows, but workflow_dispatch is exempt.
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "PR number to post CI results on"
+        required: false
 
 permissions:
   contents: read
@@ -196,7 +203,7 @@ jobs:
           INTEGRATION_RESULT: ${{ needs.integration-tests.result }}
           INTEGRATION_TIME: ${{ needs.integration-tests.outputs.run_time }}
         run: |
-          SHA=$(echo "${{ github.event.pull_request.head.sha }}" | cut -c1-7)
+          SHA=$(echo "${{ github.event.pull_request.head.sha || github.sha }}" | cut -c1-7)
           NOW=$(date -u '+%Y-%m-%d %H:%M:%S UTC')
 
           icon() { [ "$1" = "success" ] && echo ":white_check_mark:" || echo ":x:"; }
@@ -294,7 +301,13 @@ jobs:
             const fs = require('fs');
             const body = fs.readFileSync('comment-body.txt', 'utf8');
             const marker = '<!-- ci-sticky-comment -->';
-            const prNumber = context.payload.pull_request.number;
+            const prNumber = context.payload.pull_request
+              ? context.payload.pull_request.number
+              : Number(context.payload.inputs && context.payload.inputs.pr_number);
+            if (!prNumber) {
+              console.log('No PR number available; skipping comment.');
+              return;
+            }
 
             // Find existing comment
             const comments = await github.rest.issues.listComments({


### PR DESCRIPTION
PRs opened by the `check-azcopy` workflow use `GITHUB_TOKEN`, and events created with that token never trigger `pull_request` workflows (GitHub's recursion guard) — so azcopy bump PRs like #247 sat with no checks despite the PR body claiming CI validates them.

`workflow_dispatch` is exempt from the recursion guard, so:

- `check-azcopy.yaml` now dispatches `ci.yaml` on the PR branch right after opening the PR, passing the PR number as input (needs the new `actions: write` permission).
- `ci.yaml` accepts a `workflow_dispatch` trigger with an optional `pr_number` input; the sticky-comment job resolves the PR number from it (and skips commenting if absent), and the commit SHA falls back to `github.sha`.

Check runs from the dispatched CI attach to the branch head SHA, so they show up on the PR as usual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)