### PR TITLE
ci: pin ruff's rule set instead of its version

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,8 @@
+# Ruff runs unpinned in CI, so the default rule set is whatever the newest
+# release happens to ship. Selecting explicitly keeps ruff evergreen without
+# letting a new release turn green builds red overnight.
+target-version = "py312"
+line-length = 100
+
+[lint]
+select = ["E4", "E7", "E9", "F"]


### PR DESCRIPTION
CI installs ruff unpinned (`ci.yaml:31`) and the repo has no ruff config, so the
active rule set was whatever the newest release shipped as its default.

ruff 0.16.2 widened that default and turned every open PR red with 59 findings —
without a line of code changing. 32 of them are in `tests/`, and 19 of those are
naive datetimes in cron `parametrize` data. Nothing actionable.

This adds `ruff.toml` selecting `E4/E7/E9/F` — the rule set the repo has been
passing all along. Verified with `--show-settings`: 60 rules active, all E/F.
Ruff itself stays unpinned and evergreen; only the rules are fixed, so a future
release can't turn green builds red unannounced.

`I` (import sorting), `UP` and `B` are easy to add later if wanted — they'd cost
19, 20 and 22 findings respectively to clean up first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F3kdRiSB9DrpD2ynvvQ1m8