### PR TITLE
fix: close three defects before the v2.0.0 release

### DIFF
--- a/clouddump/config.py
+++ b/clouddump/config.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import shlex
 import shutil
 import sys
 import urllib.parse
@@ -325,8 +326,10 @@ def _verify_rsync_ssh(job, job_id, results):
         ssh_port = str(cfg(target, "ssh_port", "22"))
         if not source or not ssh_key or ":" not in source:
             continue
+        # Quoted for the same reason as job_rsync._build_ssh_args: rsync passes
+        # this string to a shell, and ssh_key is unconstrained operator input.
         ssh_cmd = (
-            f"ssh -i {ssh_key} -p {ssh_port} "
+            f"ssh -i {shlex.quote(ssh_key)} -p {shlex.quote(ssh_port)} "
             "-o StrictHostKeyChecking=accept-new "
             "-o BatchMode=yes -o ConnectTimeout=5"
         )

--- a/clouddump/email.py
+++ b/clouddump/email.py
@@ -14,6 +14,11 @@ from clouddump import cfg, fmt_bytes, log, redact
 
 DEFAULT_EMAIL_SIZE_LIMIT_MB = 15
 
+# A hung SMTP server must not stall the main loop. Every other blocking call in
+# CloudDump is deadline-bound (run_cmd, _run_verify, PGCONNECT_TIMEOUT); this
+# closes the last gap. Generous enough for a large attachment over a slow link.
+SMTP_TIMEOUT_SECONDS = 60
+
 
 def _resolve_smtp_security(config):
     """Determine SMTP security mode from config.
@@ -144,9 +149,9 @@ def send_email(config, subject, body, attachments=None):
     log.info("Sending email to %s from %s.", ", ".join(recipients), mail_from)
     try:
         if security == "ssl":
-            srv = smtplib.SMTP_SSL(smtp_server, smtp_port)
+            srv = smtplib.SMTP_SSL(smtp_server, smtp_port, timeout=SMTP_TIMEOUT_SECONDS)
         else:
-            srv = smtplib.SMTP(smtp_server, smtp_port)
+            srv = smtplib.SMTP(smtp_server, smtp_port, timeout=SMTP_TIMEOUT_SECONDS)
             if security == "starttls":
                 srv.starttls()
         with srv:

--- a/clouddump/job_github.py
+++ b/clouddump/job_github.py
@@ -29,8 +29,11 @@ def run_github_backup(org, logfile_path):
 
     # Write token to a temp file to keep it out of process arguments
     # (visible via ps aux). github-backup doesn't support env vars.
-    fd, token_path = tempfile.mkstemp(prefix="gh-token-", dir=destination)
-    os.chmod(token_path, 0o600)
+    #
+    # Deliberately NOT dir=destination: a hard kill between mkstemp and the
+    # finally-block would strand a live PAT inside the backup tree, which then
+    # gets mirrored onward. mkstemp already creates the file 0600.
+    fd, token_path = tempfile.mkstemp(prefix="clouddump_gh_token_")
     os.write(fd, token.encode())
     os.close(fd)
 

--- a/clouddump/job_rsync.py
+++ b/clouddump/job_rsync.py
@@ -2,6 +2,7 @@
 
 import os
 import re
+import shlex
 import subprocess
 import tempfile
 import time
@@ -19,9 +20,16 @@ _LIST_LINE_RE = re.compile(
 
 
 def _build_ssh_args(ssh_key, ssh_port):
-    """Return the common SSH option list used by rsync."""
+    """Return the common SSH option list used by rsync.
+
+    rsync hands the ``-e`` value to a shell, so every element here is joined
+    into one shell word-list by the callers. ssh_key is operator-supplied and
+    unconstrained (unlike ``source``, which _SOURCE_RE pins down), so quote it:
+    an unquoted path with a space silently breaks the command, and one with a
+    semicolon would inject.
+    """
     return [
-        "ssh", "-i", ssh_key, "-p", ssh_port,
+        "ssh", "-i", shlex.quote(ssh_key), "-p", shlex.quote(ssh_port),
         "-o", "StrictHostKeyChecking=accept-new",
         "-o", "BatchMode=yes",
     ]

--- a/tests/test_runners.py
+++ b/tests/test_runners.py
@@ -574,6 +574,40 @@ class TestGitHubRunner:
         assert "ghp_testtoken123" not in log_text
         assert "REDACTED" in log_text
 
+    def test_token_file_is_outside_backup_dir(self, monkeypatch, tmp_path, _tmp_logfile):
+        """A hard kill must not strand a live PAT inside the mirrored backup tree."""
+        from clouddump.job_github import run_github_backup
+
+        dest = tmp_path / "ghout"
+        seen = {}
+
+        def fake_run_cmd(cmd, **kwargs):
+            seen["token_path"] = cmd[cmd.index("--token") + 1][len("file://"):]
+            return 0
+
+        monkeypatch.setattr("clouddump.job_github.run_cmd", fake_run_cmd)
+        run_github_backup(self._cfg(destination=str(dest)), _tmp_logfile)
+
+        token_path = os.path.realpath(seen["token_path"])
+        assert not token_path.startswith(os.path.realpath(str(dest)))
+        assert not os.path.exists(token_path)
+
+    def test_no_token_residue_in_destination(self, monkeypatch, tmp_path, _tmp_logfile):
+        """Even mid-run, the destination holds no token-shaped file."""
+        from clouddump.job_github import run_github_backup
+
+        dest = tmp_path / "ghout"
+        during = {}
+
+        def fake_run_cmd(cmd, **kwargs):
+            during["entries"] = os.listdir(str(dest))
+            return 0
+
+        monkeypatch.setattr("clouddump.job_github.run_cmd", fake_run_cmd)
+        run_github_backup(self._cfg(destination=str(dest)), _tmp_logfile)
+
+        assert during["entries"] == []
+
 
 # ── Rsync runner ───────────────────────────────────────────────────────────
 
@@ -714,6 +748,35 @@ class TestRsyncRunner:
 
         rc = run_rsync_sync(self._cfg(ssh_key=""), _tmp_logfile)
         assert rc == 1
+
+    def test_ssh_key_with_space_is_quoted(self, monkeypatch, tmp_path, _tmp_logfile):
+        """rsync hands -e to a shell; an unquoted path with a space would split."""
+        from clouddump.job_rsync import run_rsync_sync
+
+        dest = str(tmp_path / "rsyncout")
+        calls = _capture_cmd(monkeypatch, "clouddump.job_rsync.run_cmd")
+
+        run_rsync_sync(self._cfg(destination=dest, ssh_key="/config/my key"), _tmp_logfile)
+
+        cmd = calls[0][0]
+        ssh_cmd = cmd[cmd.index("-e") + 1]
+        assert "'/config/my key'" in ssh_cmd
+
+    def test_ssh_key_cannot_inject(self, monkeypatch, tmp_path, _tmp_logfile):
+        """A semicolon in ssh_key must stay inside one shell word."""
+        from clouddump.job_rsync import run_rsync_sync
+        import shlex
+
+        dest = str(tmp_path / "rsyncout")
+        calls = _capture_cmd(monkeypatch, "clouddump.job_rsync.run_cmd")
+
+        run_rsync_sync(self._cfg(destination=dest, ssh_key="/k; touch /tmp/pwned"),
+                       _tmp_logfile)
+
+        cmd = calls[0][0]
+        ssh_cmd = cmd[cmd.index("-e") + 1]
+        # The whole key must survive shell-splitting as a single argument.
+        assert "/k; touch /tmp/pwned" in shlex.split(ssh_cmd)
 
     def test_nonzero_exit(self, monkeypatch, tmp_path, _tmp_logfile):
         from clouddump.job_rsync import run_rsync_sync

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -878,6 +878,8 @@ class _FakeSMTP:
 
     def __init__(self, *a, **k):
         self.sent = []
+        self.init_args = a
+        self.init_kwargs = k
         _FakeSMTP.last = self
 
     def __enter__(self):
@@ -925,3 +927,24 @@ def test_send_email_failure_returns_false(caplog):
 
 def test_send_email_not_configured_returns_none():
     assert send_email({}, "subj", "body") is None
+
+
+def test_send_email_ssl_passes_timeout():
+    """A hung SMTP server must not stall the main loop indefinitely."""
+    from clouddump.email import SMTP_TIMEOUT_SECONDS
+
+    with patch("clouddump.email.smtplib.SMTP_SSL", _FakeSMTP):
+        send_email(_smtp_config(), "subj", "body")
+    assert _FakeSMTP.last.init_kwargs.get("timeout") == SMTP_TIMEOUT_SECONDS
+
+
+def test_send_email_starttls_passes_timeout():
+    from clouddump.email import SMTP_TIMEOUT_SECONDS
+
+    class _FakeSTARTTLS(_FakeSMTP):
+        def starttls(self, *a, **k):
+            pass
+
+    with patch("clouddump.email.smtplib.SMTP", _FakeSTARTTLS):
+        send_email(_smtp_config(smtp_security="starttls", smtp_port=587), "subj", "body")
+    assert _FakeSMTP.last.init_kwargs.get("timeout") == SMTP_TIMEOUT_SECONDS


### PR DESCRIPTION
Three defects from the codebase review, all small and independent. Targets v2.0.0
so the major ships without a known defect.

### SMTP had no timeout — `email.py:152,154`

`smtplib.SMTP_SSL(server, port)` was constructed without `timeout=`, so a hung
mail server blocked the main loop indefinitely. This was the last unbounded
blocking call: `run_cmd` has a deadline, `_run_verify` has a timeout, `job_pgsql`
sets `PGCONNECT_TIMEOUT`. Now 60s — generous for a large attachment on a slow
link, finite either way.

### GitHub token written inside the backup directory — `job_github.py:32`

`tempfile.mkstemp(prefix="gh-token-", dir=destination)` put a live PAT in the
backup tree. On a hard kill between creation and the `finally` block it stays
there — and then gets mirrored onward to wherever the backup goes. `job_imap`
already did this correctly with the default temp dir; `job_github` now matches.
The explicit `os.chmod(0o600)` went too, since `mkstemp` already creates 0600.

### `ssh_key` interpolated unquoted into a shell string — `job_rsync.py:32`, `config.py:332`

rsync hands the `-e` value to a shell. `source` is pinned down by `_SOURCE_RE`,
but `ssh_key` was unconstrained operator input — a path with a space silently
broke the command, and one with a semicolon would inject. Both call sites now
`shlex.quote` it.

`SECURITY.md` lists "Command injection via configuration values" as in scope, so
this closed a gap in the project's own stated threat model.

Quoting rather than rejecting, so legitimate paths with spaces keep working.

## Not included

`email_on` was in the review's shortlist but the maintainer is happy with one
email per job, so it is dropped rather than deferred.

## Verification

- `226 passed, 7 skipped` (was 220 — six new tests, covering all three fixes;
  none of these paths had coverage before)
- `ruff check clouddump tests` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F3kdRiSB9DrpD2ynvvQ1m8