### PR TITLE
docs: justify compress:false on its own terms, not a vendor's

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -140,9 +140,10 @@ The source URL includes the SAS token for authentication.
   databases are dumped (except `databases_excluded`).
 - `compress`: compression inside `pg_dump` (default: `true`). The custom format
   is zlib-compressed by default, so this is not an extra pass — setting it to
-  `false` passes `-Z 0` and produces an **uncompressed** dump. Use `false` when
-  something downstream does compression or deduplication (Veeam, borg, restic):
-  a compressed dump changes wholesale between runs and defeats dedup.
+  `false` passes `-Z 0` and produces a genuinely **uncompressed** dump. Set it
+  to `false` if whatever consumes the dump does its own compression, or does
+  deduplication: a compressed dump changes wholesale between runs, so a
+  deduplicating store cannot see that most of the data is unchanged.
   Dumps are always written as `<database>.dump`, overwritten each run.
 - `db_retries`: number of retry attempts per individual database dump (default: `3`).
 

--- a/clouddump/job_pgsql.py
+++ b/clouddump/job_pgsql.py
@@ -143,9 +143,9 @@ def run_pg_dump(server, logfile_path):
 
         # The custom format is zlib-compressed by default, so a separate
         # compression pass only re-packs an already-packed file. `compress:
-        # false` therefore has to switch pg_dump's own compression off (-Z 0)
-        # — otherwise the dump stays compressed and downstream dedup (Veeam,
-        # borg, restic) still can't see through it.
+        # false` therefore has to switch pg_dump's own compression off (-Z 0),
+        # or it does not mean what it says: the dump comes out compressed
+        # either way and the option is decorative.
         cmd = ["pg_dump", "-d", _conninfo(host, port, user, database), "-F", "custom"]
         if not compress:
             cmd += ["-Z", "0"]


### PR DESCRIPTION
The `compress` comment in `job_pgsql.py` and its `CONFIGURATION.md` entry named
Veeam, borg and restic. That reasoning came from one operator's private setup
and does not belong in a general-purpose tool — CloudDump has no opinion about
what consumes its output.

`compress: false` needs no downstream justification. It means the dump is
uncompressed; that is the whole contract. The deduplication note stays, but
stated as a property of compressed files rather than as a product
recommendation.

Also removed from the published v2.0.0 release notes.

## Left alone

README's *"Restic, Borg, Veeam, tape, a RAID array in your basement — is up to
you"* is untouched. That is positioning for the "CloudDump is not a backup
system" section, it predates this work (`3310ae5`, the initial commit), and a
list of examples reads differently from a default justified by one vendor's
behaviour.

## Verification

`239 passed, 7 skipped`, ruff clean. Comment and docs only — no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F3kdRiSB9DrpD2ynvvQ1m8