### PR TITLE
docs: mark the All Mail exclude as provider-specific, not general advice

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -280,8 +280,21 @@ via Proton Bridge.
 - `delete_destination`: mirror mode — propagate remote deletions to the local
   copy (default: `true`). The remote mailbox is never touched. Set to `false`
   to keep messages locally after they are deleted on the server.
-- `exclude`: IMAP folder names to skip (default: none), e.g. `"All Mail"` to
-  avoid duplicating every message that also lives in a label.
+- `exclude`: IMAP folder names to skip (default: none).
+
+> **Note — `All Mail` on Gmail and Proton.** Both expose an `All Mail` folder
+> that contains *every* message a second time, alongside the folder or label the
+> message already lives in. Syncing it downloads and stores the whole mailbox
+> twice, so exclude it:
+>
+> ```json
+> "exclude": ["All Mail"]
+> ```
+>
+> This is provider-specific, not general advice. Providers with plain folders —
+> Fastmail, Migadu, a self-hosted Dovecot — have no such pseudo-folder, and want
+> no excludes at all. Excluding a folder that does not exist is harmless, but
+> excluding a real one silently skips mail, so check the folder list first.
 
 ### Proton Mail via Proton Bridge
 

--- a/config.schema.json
+++ b/config.schema.json
@@ -184,7 +184,7 @@
         "tls": { "type": "string", "enum": ["ssl", "starttls", "none"], "default": "ssl", "description": "Transport security. Use 'starttls' for Proton Bridge on port 1143." },
         "cert_file": { "type": "string", "description": "Path to a CA/cert to trust, for self-signed servers like Proton Bridge." },
         "delete_destination": { "type": "boolean", "default": true, "description": "Mirror mode — propagate remote deletions to the local copy. The remote mailbox is never modified." },
-        "exclude": { "type": "array", "items": { "type": "string" }, "description": "IMAP folder names to skip (e.g. \"All Mail\")." }
+        "exclude": { "type": "array", "items": { "type": "string" }, "description": "IMAP folder names to skip. Gmail and Proton need \"All Mail\" excluded; providers with plain folders need nothing." }
       },
       "additionalProperties": false
     }


### PR DESCRIPTION
The `exclude` documentation offered `"All Mail"` as its generic example, and
`config.schema.json` said the same. That reads as something every IMAP job
wants.

It is not:

- **Gmail and Proton** both expose an `All Mail` folder holding a second copy of
  every message. Syncing it stores the whole mailbox twice, so excluding it
  matters there.
- **Fastmail, Migadu, a self-hosted Dovecot** have plain folders and no such
  pseudo-folder. They want no excludes at all.

Reframed as a note naming the two providers it applies to, with the warning that
excluding a folder that *does* exist silently skips mail — worth knowing before
copying the example into a config for a provider it does not apply to.

The Proton Bridge worked example keeps its `exclude`; it is correct there.

## Verification

`239 passed, 7 skipped`, ruff clean, schema re-parsed and still matched by
`test_schema_matches_allowed_keys`. Documentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F3kdRiSB9DrpD2ynvvQ1m8