### PR TITLE
feat(imap): add info_delimiter so a Maildir can live on a Windows-backed share

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -281,6 +281,8 @@ via Proton Bridge.
   copy (default: `true`). The remote mailbox is never touched. Set to `false`
   to keep messages locally after they are deleted on the server.
 - `exclude`: IMAP folder names to skip (default: none).
+- `info_delimiter`: single character separating the flag suffix in Maildir
+  filenames (default: `:`, the Maildir standard). See the note below.
 
 > **Note — `All Mail` on Gmail and Proton.** Both expose an `All Mail` folder
 > that contains *every* message a second time, alongside the folder or label the
@@ -295,6 +297,24 @@ via Proton Bridge.
 > Fastmail, Migadu, a self-hosted Dovecot — have no such pseudo-folder, and want
 > no excludes at all. Excluding a folder that does not exist is harmless, but
 > excluding a real one silently skips mail, so check the folder list first.
+
+> **Note — a destination on an SMB share backed by Windows.** Maildir names each
+> message `<unique>:2,<flags>`, and NTFS cannot store a colon in a filename — it
+> reserves it for alternate data streams. Writing a Maildir onto a CIFS mount
+> against a Windows server therefore fails, or depends on the mount silently
+> remapping the character. Set a delimiter Windows accepts:
+>
+> ```json
+> "info_delimiter": ";"
+> ```
+>
+> **This cannot be changed after the first sync.** mbsync would not recognise
+> the existing files, would download every message again, and would leave the
+> old copies behind. Decide before the first run.
+>
+> Rejected values: whitespace, `/` (path separator), `#` (starts a comment in
+> the generated mbsyncrc), and the characters Windows reserves — picking one of
+> those would defeat the point.
 
 ### Proton Mail via Proton Bridge
 

--- a/clouddump/config.py
+++ b/clouddump/config.py
@@ -20,6 +20,13 @@ CONFIG_FILE = "/config/config.json"
 VALID_JOB_TYPES = {"azstorage", "pgsql", "github", "rsync", "imap"}
 _VALID_TABLE_FILTER_KEYS = {"tables_included", "tables_excluded"}
 VALID_IMAP_TLS = {"ssl", "starttls", "none"}
+
+# Characters that cannot serve as a Maildir info delimiter. '/' is a path
+# separator; '#' starts a comment in the generated mbsyncrc; the rest are the
+# characters Windows reserves, and picking one of those would defeat the only
+# reason to change the delimiter in the first place. ':' stays allowed — it is
+# the Maildir standard, and setting it explicitly is a legitimate no-op.
+_BAD_INFO_DELIMITERS = set('/#*?"<>|' + chr(92))
 # Every key CloudDump reads. An unrecognised key is refused at startup rather
 # than ignored: a config that does not mean what it says will never fix itself,
 # and the defaults it silently falls back to are not harmless (delete_destination
@@ -55,7 +62,7 @@ TARGET_KEYS = {
     "rsync": {"source", "destination", "ssh_key", "ssh_port", "delete_destination",
               "delete_excluded", "exclude", "min_age_days"},
     "imap": {"host", "port", "user", "pass", "destination", "tls", "cert_file",
-             "delete_destination", "exclude"},
+             "delete_destination", "exclude", "info_delimiter"},
 }
 
 
@@ -330,9 +337,22 @@ def validate_jobs(jobs):
                               acct_type, acct_name, job_id, ", ".join(sorted(VALID_GITHUB_ACCOUNT_TYPES)))
                     errors += 1
 
-        # Validate tls mode for IMAP accounts (config error, not connectivity)
+        # Validate tls mode and info_delimiter for IMAP accounts
         if job_type == "imap":
             for account in cfg(job, "accounts", []):
+                delim = account.get("info_delimiter")
+                if delim is not None:
+                    if not isinstance(delim, str) or len(delim) != 1:
+                        log.error("info_delimiter for '%s' in job ID %s must be exactly "
+                                  "one character, got %r.",
+                                  cfg(account, "user"), job_id, delim)
+                        errors += 1
+                    elif delim.isspace() or delim in _BAD_INFO_DELIMITERS:
+                        log.error("info_delimiter %r for '%s' in job ID %s cannot be used. "
+                                  "Not allowed: whitespace, and %s.",
+                                  delim, cfg(account, "user"), job_id,
+                                  " ".join(sorted(_BAD_INFO_DELIMITERS)))
+                        errors += 1
                 tls = cfg(account, "tls", "ssl")
                 if tls not in VALID_IMAP_TLS:
                     log.error("Invalid tls '%s' for '%s' in job ID %s. Must be one of: %s.",

--- a/clouddump/job_imap.py
+++ b/clouddump/job_imap.py
@@ -48,9 +48,17 @@ def _quote(value):
 
 
 def _build_config(host, port, user, passfile, tls_type, cert_file,
-                  destination, patterns, delete):
+                  destination, patterns, delete, info_delimiter=None):
     """Render an mbsyncrc for a one-directional far->near (remote->local) sync."""
     cert_line = f"CertificateFile {_quote(cert_file)}\n" if cert_file else ""
+
+    # Maildir separates the flag suffix from the unique part with ':' by
+    # default, which NTFS cannot store — it reserves the colon for alternate
+    # data streams. A destination on an SMB share backed by Windows therefore
+    # needs a different delimiter. Emitted bare rather than quoted: validation
+    # has already ruled out whitespace, quotes and '#' (the mbsyncrc comment
+    # character), so there is nothing left for quoting to protect.
+    delim_line = f"InfoDelimiter {info_delimiter}\n" if info_delimiter else ""
 
     if delete:
         # Full mirror: pull new/changed/deleted, and actually remove locally.
@@ -76,6 +84,7 @@ def _build_config(host, port, user, passfile, tls_type, cert_file,
         "MaildirStore clouddump-local\n"
         f"Path {_quote(destination + '/')}\n"
         f"Inbox {_quote(destination + '/INBOX')}\n"
+        f"{delim_line}"
         "SubFolders Verbatim\n"
         "\n"
         "Channel clouddump\n"
@@ -97,6 +106,7 @@ def run_imap_sync(target, logfile_path):
     cert_file = cfg(target, "cert_file")
     delete = cfg(target, "delete_destination", True)
     exclude = cfg(target, "exclude", [])
+    info_delimiter = cfg(target, "info_delimiter") or None
 
     # Default port depends on transport: 993 for implicit TLS (IMAPS),
     # 143 for STARTTLS or plaintext.
@@ -146,7 +156,8 @@ def run_imap_sync(target, logfile_path):
         with os.fdopen(pass_fd, "w") as f:
             f.write(password)
         config = _build_config(host, port, user, passfile, tls_type,
-                               cert_file, destination, patterns, delete)
+                               cert_file, destination, patterns, delete,
+                               info_delimiter)
         with os.fdopen(config_fd, "w") as f:
             f.write(config)
 

--- a/config.schema.json
+++ b/config.schema.json
@@ -184,7 +184,8 @@
         "tls": { "type": "string", "enum": ["ssl", "starttls", "none"], "default": "ssl", "description": "Transport security. Use 'starttls' for Proton Bridge on port 1143." },
         "cert_file": { "type": "string", "description": "Path to a CA/cert to trust, for self-signed servers like Proton Bridge." },
         "delete_destination": { "type": "boolean", "default": true, "description": "Mirror mode — propagate remote deletions to the local copy. The remote mailbox is never modified." },
-        "exclude": { "type": "array", "items": { "type": "string" }, "description": "IMAP folder names to skip. Gmail and Proton need \"All Mail\" excluded; providers with plain folders need nothing." }
+        "exclude": { "type": "array", "items": { "type": "string" }, "description": "IMAP folder names to skip. Gmail and Proton need \"All Mail\" excluded; providers with plain folders need nothing." },
+        "info_delimiter": { "type": "string", "minLength": 1, "maxLength": 1, "description": "Character separating the flag suffix in Maildir filenames. Defaults to \":\", which Windows/NTFS cannot store — use \";\" for a destination on an SMB share. Cannot be changed after the first sync." }
       },
       "additionalProperties": false
     }

--- a/tests/test_runners.py
+++ b/tests/test_runners.py
@@ -1128,6 +1128,32 @@ class TestImapRunner:
 
         assert 'CertificateFile "/config/bridge.pem"' in calls[0]["config"]
 
+    def test_no_info_delimiter_by_default(self, monkeypatch, tmp_path, _tmp_logfile):
+        """Unset means mbsync keeps the Maildir standard colon."""
+        from clouddump.job_imap import run_imap_sync
+
+        dest = str(tmp_path / "mail")
+        calls = self._capture(monkeypatch)
+
+        run_imap_sync(self._cfg(destination=dest), _tmp_logfile)
+
+        assert "InfoDelimiter" not in calls[0]["config"]
+
+    def test_info_delimiter_emitted(self, monkeypatch, tmp_path, _tmp_logfile):
+        """A destination on an SMB share backed by Windows cannot store ':'."""
+        from clouddump.job_imap import run_imap_sync
+
+        dest = str(tmp_path / "mail")
+        calls = self._capture(monkeypatch)
+
+        run_imap_sync(self._cfg(destination=dest, info_delimiter=";"), _tmp_logfile)
+
+        config = calls[0]["config"]
+        assert "InfoDelimiter ;" in config
+        # Must land inside the MaildirStore block, before SubFolders.
+        assert config.index("MaildirStore") < config.index("InfoDelimiter")
+        assert config.index("InfoDelimiter") < config.index("SubFolders")
+
     def test_exclude_patterns(self, monkeypatch, tmp_path, _tmp_logfile):
         from clouddump.job_imap import run_imap_sync
 

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -418,6 +418,60 @@ def test_validate_jobs_github_valid():
 
 
 
+# ── imap info_delimiter ─────────────────────────────────────────────────────
+
+
+def _imap_job(**account_over):
+    account = {"host": "imap.example.com", "user": "u@example.com",
+               "pass": "x", "destination": "/tmp/mail"}
+    account.update(account_over)
+    return _job(type="imap", accounts=[account])
+
+
+def _delim_errors(caplog):
+    return [r.getMessage() for r in caplog.records if "info_delimiter" in r.getMessage()]
+
+
+def test_info_delimiter_single_char_accepted(caplog):
+    with caplog.at_level(logging.ERROR, logger="clouddump"):
+        validate_jobs([_imap_job(info_delimiter=";")])
+    assert _delim_errors(caplog) == []
+
+
+def test_info_delimiter_omitted_is_fine(caplog):
+    with caplog.at_level(logging.ERROR, logger="clouddump"):
+        validate_jobs([_imap_job()])
+    assert _delim_errors(caplog) == []
+
+
+def test_info_delimiter_colon_allowed(caplog):
+    """The Maildir standard; setting it explicitly is a legitimate no-op."""
+    with caplog.at_level(logging.ERROR, logger="clouddump"):
+        validate_jobs([_imap_job(info_delimiter=":")])
+    assert _delim_errors(caplog) == []
+
+
+@pytest.mark.parametrize("delim", ["", ";;", "abc"])
+def test_info_delimiter_must_be_one_char(delim, caplog):
+    with caplog.at_level(logging.ERROR, logger="clouddump"):
+        validate_jobs([_imap_job(info_delimiter=delim)])
+    assert any("exactly one character" in m for m in _delim_errors(caplog))
+
+
+@pytest.mark.parametrize("delim", ["/", "#", "*", "?", '"', "<", ">", "|", "\\", " "])
+def test_info_delimiter_rejects_unusable_characters(delim, caplog):
+    """Path separator, mbsyncrc comment char, and the Windows-reserved set."""
+    with caplog.at_level(logging.ERROR, logger="clouddump"):
+        validate_jobs([_imap_job(info_delimiter=delim)])
+    assert any("cannot be used" in m for m in _delim_errors(caplog))
+
+
+def test_info_delimiter_non_string_rejected(caplog):
+    with caplog.at_level(logging.ERROR, logger="clouddump"):
+        validate_jobs([_imap_job(info_delimiter=59)])
+    assert any("exactly one character" in m for m in _delim_errors(caplog))
+
+
 # ── unknown config keys ─────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## The problem

Maildir names each message `<unique>:2,<flags>`. **NTFS cannot store a colon in
a filename** — it reserves it for alternate data streams. Writing a Maildir onto
a CIFS mount against a Windows server therefore either fails outright, or
depends on the mount silently remapping the character.

That makes the `imap` job unusable for anyone whose backup destination is an SMB
share on Windows, which is a common shape for this tool.

## The fix

isync has supported `InfoDelimiter` for exactly this since 1.4, and Debian 13
ships 1.5.1. Its own manual says:

> The Maildir standard defines this to be the colon, but this is incompatible
> with DOS/Windows file systems.

This exposes it as an optional per-account key:

```json
{
  "type": "imap",
  "accounts": [
    {
      "host": "imap.fastmail.com",
      "destination": "/mnt/clouddump/mail/user1",
      "info_delimiter": ";"
    }
  ]
}
```

which emits `InfoDelimiter ;` into the generated `MaildirStore` block.

## Validation

Rejected: not exactly one character, whitespace, `/` (path separator), `#`
(starts a comment in the generated mbsyncrc — which is also why the value is
emitted bare rather than quoted), and the characters Windows reserves. Choosing
one of the latter would defeat the only reason to set the option.

`:` stays allowed. It is the Maildir standard, and setting it explicitly is a
legitimate no-op.

## The constraint worth reading

**The delimiter cannot be changed after the first sync.** mbsync would not
recognise the existing files, would download every message again, and would
leave the old copies behind. Documented prominently rather than buried in the
key list.

## Why not `mapposix` on the mount

Adding `mapposix` to the CIFS options needs no code and would also work. It was
rejected because it hides the problem in a translation layer: Windows still
stores a character from a private Unicode range that nobody can type, and a
direct restore on the Windows side produces unusable filenames. With
`InfoDelimiter` the names are natively valid at every hop — Linux, the wire, the
Windows filesystem, and whatever backs it up from there.

## Verification

- `258 passed, 7 skipped` (was 239 — nineteen new tests)
- `ruff check clouddump tests` clean
- Smoke-checked the rendered mbsyncrc: `InfoDelimiter` lands inside the
  `MaildirStore` block, after `Inbox` and before `SubFolders`
- `test_schema_matches_allowed_keys` still green, so `config.schema.json` and
  the runtime key set agree

## Sources

- [mbsync manual — MaildirStore / InfoDelimiter](https://isync.sourceforge.io/mbsync.html)
- [Debian trixie — isync 1.5.1-1](https://packages.debian.org/trixie/isync)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F3kdRiSB9DrpD2ynvvQ1m8