### PR TITLE
fix: correctness defects, orchestrator coverage, and per-target retry

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -90,6 +90,12 @@ kubectl exec deploy/clouddump -- kill -USR1 1
 | `timeout` | No | `604800` (7 days) | Job timeout in seconds |
 | `retries` | No | `3` | Number of attempts on failure |
 
+A job may hold several targets, and all of them are attempted even if earlier
+ones fail — one bad server does not stop the rest. A retry then re-runs **only
+the targets that failed**, so a target that already succeeded is not synced
+again. A crash (as opposed to a target reporting failure) says nothing about
+what got through, so it retries the whole job.
+
 Plus type-specific fields (`blobstorages`, `servers`, `organizations`,
 `targets`, `accounts`) — see below.
 

--- a/clouddump/__main__.py
+++ b/clouddump/__main__.py
@@ -188,7 +188,12 @@ def main():
 
                 job_type = cfg(job, "type")
                 if not cfg(job, "enabled", True):
-                    log.info("Skipping disabled job", extra={"job_id": job_id, "job_type": job_type})
+                    # "job", not "job_id": _EXTRA_FIELDS only carries the former,
+                    # and the JSON formatter drops anything it does not know. This
+                    # line runs before current_job is set, so the id has to be
+                    # passed explicitly to appear at all.
+                    log.info("Skipping disabled job",
+                             extra={"job": job_id, "job_type": job_type})
                     continue
 
                 clouddump.current_job = job_id

--- a/clouddump/__main__.py
+++ b/clouddump/__main__.py
@@ -1,5 +1,6 @@
 """Entry point — run with ``python -m clouddump``."""
 
+import glob
 import json
 import logging
 import os
@@ -72,6 +73,110 @@ def _tool_versions():
             pass
 
     return "\n".join(versions)
+
+
+def _run_one_job(job, config, version, host):
+    """Run one job to completion: retries, per-attempt logging, report, cleanup.
+
+    Returns the job's final exit code. The caller owns the succeeded/failed
+    tally and the run-level summary; everything scoped to a single job lives
+    here, so it can be exercised without driving the whole main loop.
+    """
+    job_id = cfg(job, "id")
+    job_type = cfg(job, "type")
+    # If retries were somehow 0 the attempt loop never runs; report failure
+    # rather than inheriting whatever the previous job left in this name.
+    result = 1
+    clouddump.current_job = job_id
+    try:
+        log.info("Starting job", extra={"job_type": job_type})
+
+        timeout = int(cfg(job, "timeout", 604800))
+        max_attempts = int(cfg(job, "retries", 3))
+
+        job_t_start = time.time()
+        logfile_paths = []
+        final_attempt = 0
+
+        for attempt in range(1, max_attempts + 1):
+            final_attempt = attempt
+            fd, logfile_path = tempfile.mkstemp(prefix=f"clouddump-{job_id}-", suffix=".log")
+            os.close(fd)
+            logfile_paths.append(logfile_path)
+
+            t_start = time.time()
+            clouddump.job_deadline = t_start + timeout
+
+            file_handler = _add_file_handler(logfile_path)
+            log.info("Starting attempt", extra={"attempt": attempt, "max_attempts": max_attempts})
+
+            net_before = net_bytes()
+
+            try:
+                result = execute_job(job, logfile_path)
+                t_end = time.time()
+            except Exception:
+                t_end = time.time()
+                tb = traceback.format_exc()
+                log.error("Crashed:\n%s", tb)
+                result = 1
+            finally:
+                clouddump.job_deadline = None
+                log.removeHandler(file_handler)
+                file_handler.close()
+
+            elapsed = int(t_end - t_start)
+
+            net_after = net_bytes()
+            rx_bytes = max(0, net_after[0] - net_before[0]) if net_before and net_after else None
+            tx_bytes = max(0, net_after[1] - net_before[1]) if net_before and net_after else None
+            metric_status = "success" if result == 0 else "failure"
+            update_job_metric(job_id, job_type, metric_status, elapsed, rx=rx_bytes, tx=tx_bytes)
+
+            extras = {"status": metric_status, "elapsed_s": elapsed,
+                      "attempt": attempt, "max_attempts": max_attempts}
+            if rx_bytes is not None:
+                extras["rx_bytes"] = rx_bytes
+            if tx_bytes is not None:
+                extras["tx_bytes"] = tx_bytes
+
+            if result == 0:
+                log.info("Attempt completed successfully", extra=extras)
+                break
+            else:
+                extras["exit_code"] = result
+                log.warning("Attempt completed with errors", extra=extras)
+                if attempt < max_attempts:
+                    log.warning("Retrying in 60s...")
+                    for _ in range(60):
+                        if clouddump.shutdown_requested:
+                            break
+                        time.sleep(1)
+                else:
+                    log.error("Failed after all attempts",
+                              extra={"max_attempts": max_attempts})
+
+        # Determine three-tier status and send one email
+        job_t_end = time.time()
+        if result == 0 and final_attempt == 1:
+            job_status = "Success"
+        elif result == 0:
+            job_status = "Warning"
+        else:
+            job_status = "Failure"
+
+        send_job_report(config, version, host, job, result,
+                        job_t_start, job_t_end, logfile_paths,
+                        status=job_status, attempts_used=final_attempt,
+                        max_attempts=max_attempts)
+
+        for lf in logfile_paths:
+            for sidecar in glob.glob(f"{lf}.*.log"):
+                _safe_remove(sidecar)
+            _safe_remove(lf)
+        return result
+    finally:
+        clouddump.current_job = ""
 
 
 def main():
@@ -196,112 +301,15 @@ def main():
                              extra={"job": job_id, "job_type": job_type})
                     continue
 
-                clouddump.current_job = job_id
-                log.info("Starting job", extra={"job_type": job_type})
-
-                timeout = int(cfg(job, "timeout", 604800))
-                max_attempts = int(cfg(job, "retries", 3))
-
-                job_t_start = time.time()
-                logfile_paths = []
-                total_rx = 0
-                total_tx = 0
-                final_attempt = 0
-
-                for attempt in range(1, max_attempts + 1):
-                    final_attempt = attempt
-                    fd, logfile_path = tempfile.mkstemp(prefix=f"clouddump-{job_id}-", suffix=".log")
-                    os.close(fd)
-                    logfile_paths.append(logfile_path)
-
-                    t_start = time.time()
-                    clouddump.job_deadline = t_start + timeout
-
-                    file_handler = _add_file_handler(logfile_path)
-                    log.info("Starting attempt", extra={"attempt": attempt, "max_attempts": max_attempts})
-
-                    net_before = net_bytes()
-
-                    try:
-                        result = execute_job(job, logfile_path)
-                        t_end = time.time()
-                    except Exception:
-                        t_end = time.time()
-                        tb = traceback.format_exc()
-                        log.error("Crashed:\n%s", tb)
-                        result = 1
-                    finally:
-                        clouddump.job_deadline = None
-                        log.removeHandler(file_handler)
-                        file_handler.close()
-
-                    elapsed = int(t_end - t_start)
-                    minutes, seconds = divmod(elapsed, 60)
-
-                    net_after = net_bytes()
-                    if net_before and net_after:
-                        total_rx += max(0, net_after[0] - net_before[0])
-                        total_tx += max(0, net_after[1] - net_before[1])
-
-                    rx_bytes = max(0, net_after[0] - net_before[0]) if net_before and net_after else None
-                    tx_bytes = max(0, net_after[1] - net_before[1]) if net_before and net_after else None
-                    metric_status = "success" if result == 0 else "failure"
-                    update_job_metric(job_id, job_type, metric_status, elapsed, rx=rx_bytes, tx=tx_bytes)
-
-                    extras = {"status": metric_status, "elapsed_s": elapsed,
-                              "attempt": attempt, "max_attempts": max_attempts}
-                    if rx_bytes is not None:
-                        extras["rx_bytes"] = rx_bytes
-                    if tx_bytes is not None:
-                        extras["tx_bytes"] = tx_bytes
-
-                    if result == 0:
-                        log.info("Attempt completed successfully", extra=extras)
-                        break
-                    else:
-                        extras["exit_code"] = result
-                        log.warning("Attempt completed with errors", extra=extras)
-                        if attempt < max_attempts:
-                            log.warning("Retrying in 60s...")
-                            for _ in range(60):
-                                if clouddump.shutdown_requested:
-                                    break
-                                time.sleep(1)
-                        else:
-                            log.error("Failed after all attempts",
-                                      extra={"max_attempts": max_attempts})
-
-                # Determine three-tier status and send one email
-                job_t_end = time.time()
-                if result == 0 and final_attempt == 1:
-                    job_status = "Success"
-                elif result == 0:
-                    job_status = "Warning"
-                else:
-                    job_status = "Failure"
-
-                send_job_report(config, version, host, job, result,
-                                job_t_start, job_t_end, logfile_paths,
-                                status=job_status, attempts_used=final_attempt,
-                                max_attempts=max_attempts)
-
-                import glob
-                for lf in logfile_paths:
-                    for sidecar in glob.glob(f"{lf}.*.log"):
-                        _safe_remove(sidecar)
-                    _safe_remove(lf)
-
+                result = _run_one_job(job, config, version, host)
                 if result == 0:
                     succeeded += 1
                 else:
                     failed += 1
 
-                clouddump.current_job = ""
-
             if not clouddump.shutdown_requested:
                 run_end = datetime.now(timezone.utc)
                 run_elapsed = int((run_end - run_start).total_seconds())
-                run_min, run_sec = divmod(run_elapsed, 60)
                 run_extras = {"succeeded": succeeded, "failed": failed,
                               "total": len(jobs), "elapsed_s": run_elapsed}
                 if failed:

--- a/clouddump/__main__.py
+++ b/clouddump/__main__.py
@@ -97,6 +97,10 @@ def _run_one_job(job, config, version, host):
         job_t_start = time.time()
         logfile_paths = []
         final_attempt = 0
+        # Targets still to run. After a partial failure the next attempt gets
+        # only what failed, so a healthy target is not re-synced — and for a
+        # pgsql server, not dumped a second time.
+        pending = None
 
         for attempt in range(1, max_attempts + 1):
             final_attempt = attempt
@@ -113,13 +117,16 @@ def _run_one_job(job, config, version, host):
             net_before = net_bytes()
 
             try:
-                result = execute_job(job, logfile_path)
+                result, pending = execute_job(job, logfile_path, pending)
                 t_end = time.time()
             except Exception:
                 t_end = time.time()
                 tb = traceback.format_exc()
                 log.error("Crashed:\n%s", tb)
                 result = 1
+                # A crash says nothing about which targets got through,
+                # so fall back to retrying the whole job.
+                pending = None
             finally:
                 clouddump.job_deadline = None
                 log.removeHandler(file_handler)
@@ -147,7 +154,11 @@ def _run_one_job(job, config, version, host):
                 extras["exit_code"] = result
                 log.warning("Attempt completed with errors", extra=extras)
                 if attempt < max_attempts:
-                    log.warning("Retrying in 60s...")
+                    if pending:
+                        log.warning("Retrying %d failed target(s) in 60s...",
+                                    len(pending))
+                    else:
+                        log.warning("Retrying in 60s...")
                     for _ in range(60):
                         if clouddump.shutdown_requested:
                             break

--- a/clouddump/config.py
+++ b/clouddump/config.py
@@ -337,6 +337,26 @@ def validate_jobs(jobs):
                               acct_type, acct_name, job_id, ", ".join(sorted(VALID_GITHUB_ACCOUNT_TYPES)))
                     errors += 1
 
+        # Two IMAP accounts must not share a destination: mbsync keeps its sync
+        # state inside the Maildir, so a shared directory means each account
+        # overwrites the other's state. With delete_destination at its default
+        # of true, that resolves as deletion.
+        if job_type == "imap":
+            seen_dests = {}
+            for account in cfg(job, "accounts", []):
+                dest = cfg(account, "destination")
+                if not dest:
+                    continue
+                key = os.path.normpath(dest)
+                if key in seen_dests:
+                    log.error("Accounts '%s' and '%s' in job ID %s share destination "
+                              "'%s'. mbsync stores its sync state there, so they would "
+                              "corrupt each other. Give each account its own directory.",
+                              seen_dests[key], cfg(account, "user"), job_id, dest)
+                    errors += 1
+                else:
+                    seen_dests[key] = cfg(account, "user")
+
         # Validate tls mode and info_delimiter for IMAP accounts
         if job_type == "imap":
             for account in cfg(job, "accounts", []):

--- a/clouddump/health.py
+++ b/clouddump/health.py
@@ -1,10 +1,17 @@
 """Minimal HTTP health-check endpoint for CloudDump."""
 
+import copy
 import json
 import threading
 from http.server import HTTPServer, BaseHTTPRequestHandler
 
 from clouddump import log
+
+# The main thread writes _state while the HTTP thread serialises it. Without
+# this lock a scrape landing mid-write can raise "dictionary changed size during
+# iteration" inside json.dumps and turn into a 500 — a hole in the metrics for
+# whatever is polling /healthz.
+_lock = threading.Lock()
 
 # Module-level state, updated by __main__ after each run completes.
 _state = {
@@ -16,7 +23,7 @@ _state = {
 
 def update_last_run(started, finished, succeeded, failed, total):
     """Record the result of the most recent backup run."""
-    _state["last_run"] = {
+    entry = {
         "started": started.isoformat(),
         "finished": finished.isoformat(),
         "finished_epoch": int(finished.timestamp()),
@@ -25,6 +32,8 @@ def update_last_run(started, finished, succeeded, failed, total):
         "failed": failed,
         "has_run": True,
     }
+    with _lock:
+        _state["last_run"] = entry
 
 
 def update_job_metric(job_id, job_type, status, elapsed, rx=None, tx=None):
@@ -38,17 +47,19 @@ def update_job_metric(job_id, job_type, status, elapsed, rx=None, tx=None):
         entry["rx_bytes"] = rx
     if tx is not None:
         entry["tx_bytes"] = tx
-    _state["jobs"][job_id] = entry
+    with _lock:
+        _state["jobs"][job_id] = entry
 
 
 class _Handler(BaseHTTPRequestHandler):
     def do_GET(self):
         if self.path == "/healthz":
-            body = json.dumps({
-                "status": "ok",
-                "last_run": _state["last_run"],
-                "jobs": _state["jobs"],
-            })
+            with _lock:
+                snapshot = copy.deepcopy({
+                    "last_run": _state["last_run"],
+                    "jobs": _state["jobs"],
+                })
+            body = json.dumps({"status": "ok", **snapshot})
             self.send_response(200)
             self.send_header("Content-Type", "application/json")
             self.end_headers()
@@ -63,13 +74,19 @@ class _Handler(BaseHTTPRequestHandler):
 
 
 def start_health_server(port=8080, log_requests=False):
-    """Start the health HTTP server in a daemon thread."""
+    """Start the health HTTP server in a daemon thread.
+
+    Returns the HTTPServer, or None if the port could not be bound. The caller
+    in __main__ ignores it; tests use it to discover the bound port when they
+    pass port=0.
+    """
     _state["log_requests"] = log_requests
     try:
         server = HTTPServer(("", port), _Handler)
     except OSError as exc:
         log.warning("Could not start health endpoint on port %d: %s", port, exc)
-        return
+        return None
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
-    log.info("Health endpoint listening on port %d", port)
+    log.info("Health endpoint listening on port %d", server.server_address[1])
+    return server

--- a/clouddump/jobs.py
+++ b/clouddump/jobs.py
@@ -37,35 +37,46 @@ def _target_label(target, job_type):
     return val
 
 
-def execute_job(job, logfile_path):
-    """Dispatch a job to the appropriate runner by type. Returns exit code.
+def execute_job(job, logfile_path, targets=None):
+    """Dispatch a job to its runner. Returns ``(exit_code, failed_targets)``.
 
-    Each job type may contain multiple targets (buckets, blobstorages, servers).
-    All targets are attempted even if earlier ones fail; the worst exit code wins.
+    Each job type may contain multiple targets (blobstorages, servers, ...).
+    All are attempted even if earlier ones fail; the worst exit code wins.
+
+    *targets* overrides the job's own list. The retry loop passes the subset that
+    failed last time, so a second attempt does not re-run targets that already
+    succeeded — re-syncing a healthy target is wasted work at best, and for a
+    pgsql server it is a second full dump.
+
+    The returned list holds the target dicts that failed, ready to be passed back
+    in as *targets* on the next attempt.
     """
     job_type = cfg(job, "type")
 
     entry = _RUNNERS.get(job_type)
     if entry is None:
         log.error("Unknown job type %s.", job_type)
-        return 1
+        return 1, []
 
     key, runner = entry
-    targets = cfg(job, key, [])
+    if targets is None:
+        targets = cfg(job, key, [])
     if not targets:
         log.error("No %s configured.", key)
-        return 1
+        return 1, []
 
     rc = 0
     results = []
+    failed = []
     for target in targets:
         r = runner(target, logfile_path)
         results.append((_target_label(target, job_type), r))
         if r != 0:
             rc = max(rc, r)
+            failed.append(target)
 
     if len(results) > 1:
         lines = [f"  {'OK  ' if r == 0 else 'FAIL'}  {label}" for label, r in results]
         ok = sum(1 for _, r in results if r == 0)
         log.info("Job summary (%d/%d OK):\n%s", ok, len(results), "\n".join(lines))
-    return rc
+    return rc, failed

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,196 @@
+"""Tests for the per-job orchestration in clouddump.__main__.
+
+_run_one_job owns retries, the three-tier status, the log-file lifecycle and the
+report email. That email is the only signal some deployments have that a backup
+ran, so the behaviour here is worth pinning down.
+"""
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+import clouddump
+from clouddump.__main__ import _run_one_job
+
+
+@pytest.fixture(autouse=True)
+def _reset_state():
+    clouddump.current_job = ""
+    clouddump.job_deadline = None
+    clouddump.shutdown_requested = False
+    yield
+    clouddump.current_job = ""
+    clouddump.job_deadline = None
+    clouddump.shutdown_requested = False
+
+
+@pytest.fixture
+def reports():
+    """Capture send_job_report calls as kwargs dicts."""
+    captured = []
+
+    def fake(config, version, host, job, exit_code, t_start, t_end, logfile_paths, **kw):
+        captured.append({"exit_code": exit_code, "job": job,
+                         "logfile_paths": list(logfile_paths), **kw})
+
+    with patch("clouddump.__main__.send_job_report", fake):
+        yield captured
+
+
+def _job(**over):
+    base = {"id": "test-job", "type": "pgsql", "retries": 3, "timeout": 60}
+    base.update(over)
+    return base
+
+
+def _run(job, exec_results, reports, sleepless=True):
+    """Drive _run_one_job with execute_job returning each of *exec_results*."""
+    calls = []
+    seq = iter(exec_results)
+
+    def fake_execute(j, logfile_path):
+        calls.append(logfile_path)
+        r = next(seq)
+        if isinstance(r, Exception):
+            raise r
+        return r
+
+    with patch("clouddump.__main__.execute_job", fake_execute):
+        if sleepless:
+            with patch("clouddump.__main__.time.sleep", lambda _: None):
+                rc = _run_one_job(job, {}, "9.9.9", "testhost")
+        else:
+            rc = _run_one_job(job, {}, "9.9.9", "testhost")
+    return rc, calls
+
+
+# ── exit code and retries ───────────────────────────────────────────────────
+
+
+def test_success_first_attempt(reports):
+    rc, calls = _run(_job(), [0], reports)
+    assert rc == 0
+    assert len(calls) == 1
+    assert reports[0]["status"] == "Success"
+    assert reports[0]["attempts_used"] == 1
+
+
+def test_retries_until_success(reports):
+    rc, calls = _run(_job(), [1, 1, 0], reports)
+    assert rc == 0
+    assert len(calls) == 3
+
+
+def test_success_after_retry_is_reported_as_warning(reports):
+    """A backup that only succeeded on the third try is not a clean success."""
+    _run(_job(), [1, 1, 0], reports)
+    assert reports[0]["status"] == "Warning"
+    assert reports[0]["attempts_used"] == 3
+
+
+def test_exhausted_retries_is_failure(reports):
+    rc, _ = _run(_job(retries=2), [1, 1], reports)
+    assert rc == 1
+    assert reports[0]["status"] == "Failure"
+    assert reports[0]["attempts_used"] == 2
+
+
+def test_retries_setting_is_honoured(reports):
+    _, calls = _run(_job(retries=5), [1, 1, 1, 1, 0], reports)
+    assert len(calls) == 5
+
+
+def test_stops_at_first_success(reports):
+    _, calls = _run(_job(retries=5), [0, 0, 0, 0, 0], reports)
+    assert len(calls) == 1
+
+
+# ── crashes ─────────────────────────────────────────────────────────────────
+
+
+def test_runner_exception_becomes_a_failed_attempt(reports):
+    rc, calls = _run(_job(retries=2), [RuntimeError("boom"), 0], reports)
+    assert rc == 0
+    assert len(calls) == 2, "a crash must be retried like any other failure"
+
+
+def test_crash_on_every_attempt_reports_failure(reports):
+    rc, _ = _run(_job(retries=2), [RuntimeError("boom"), RuntimeError("boom")], reports)
+    assert rc == 1
+    assert reports[0]["status"] == "Failure"
+
+
+# ── reporting always happens ────────────────────────────────────────────────
+
+
+def test_report_sent_exactly_once_per_job(reports):
+    _run(_job(retries=3), [1, 1, 0], reports)
+    assert len(reports) == 1, "one email per job, not one per attempt"
+
+
+def test_report_sent_even_when_every_attempt_crashes(reports):
+    _run(_job(retries=1), [RuntimeError("boom")], reports)
+    assert len(reports) == 1, "a crashing job must still be reported"
+
+
+def test_one_logfile_per_attempt(reports):
+    _run(_job(retries=3), [1, 1, 0], reports)
+    assert len(reports[0]["logfile_paths"]) == 3
+
+
+# ── side effects ────────────────────────────────────────────────────────────
+
+
+def test_logfiles_are_cleaned_up(reports):
+    _run(_job(retries=2), [1, 0], reports)
+    for path in reports[0]["logfile_paths"]:
+        assert not os.path.exists(path)
+
+
+def test_current_job_is_set_during_and_cleared_after(reports):
+    seen = []
+
+    def fake_execute(j, logfile_path):
+        seen.append(clouddump.current_job)
+        return 0
+
+    with patch("clouddump.__main__.execute_job", fake_execute):
+        _run_one_job(_job(), {}, "9.9.9", "testhost")
+
+    assert seen == ["test-job"]
+    assert clouddump.current_job == ""
+
+
+def test_current_job_cleared_even_when_reporting_raises():
+    def boom(*a, **k):
+        raise RuntimeError("smtp exploded")
+
+    with patch("clouddump.__main__.execute_job", lambda j, p: 0), \
+         patch("clouddump.__main__.send_job_report", boom):
+        with pytest.raises(RuntimeError):
+            _run_one_job(_job(), {}, "9.9.9", "testhost")
+
+    assert clouddump.current_job == "", "a failed report must not leak job context"
+
+
+def test_deadline_is_set_per_attempt_and_cleared(reports):
+    seen = []
+
+    def fake_execute(j, logfile_path):
+        seen.append(clouddump.job_deadline)
+        return 0
+
+    with patch("clouddump.__main__.execute_job", fake_execute):
+        _run_one_job(_job(timeout=1234), {}, "9.9.9", "testhost")
+
+    assert seen[0] is not None
+    assert clouddump.job_deadline is None, "deadline must not leak past the job"
+
+
+def test_zero_retries_reports_failure_not_stale_state(reports):
+    """Validation forbids retries < 1, but the guard must not read a stale result."""
+    rc, calls = _run(_job(retries=0), [], reports)
+    assert calls == []
+    assert rc == 1
+    assert reports[0]["status"] == "Failure"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -49,12 +49,15 @@ def _run(job, exec_results, reports, sleepless=True):
     calls = []
     seq = iter(exec_results)
 
-    def fake_execute(j, logfile_path):
+    def fake_execute(j, logfile_path, targets=None):
         calls.append(logfile_path)
         r = next(seq)
         if isinstance(r, Exception):
             raise r
-        return r
+        # execute_job returns (exit_code, failed_targets); the retry loop feeds
+        # that list back in. A non-empty list here would make the fake look like
+        # a partial failure, which these tests do not model.
+        return r, []
 
     with patch("clouddump.__main__.execute_job", fake_execute):
         if sleepless:
@@ -106,6 +109,75 @@ def test_stops_at_first_success(reports):
     assert len(calls) == 1
 
 
+# ── retry only what failed ──────────────────────────────────────────────────
+
+
+def test_retry_receives_only_the_failed_targets(reports):
+    """The whole point: a healthy target is not re-run on the next attempt."""
+    b = {"id": "b"}
+    seen = []
+    responses = [(1, [b]), (0, [])]
+
+    def fake_execute(job, logfile_path, targets=None):
+        seen.append(targets)
+        return responses[len(seen) - 1]
+
+    with patch("clouddump.__main__.execute_job", fake_execute),          patch("clouddump.__main__.time.sleep", lambda _: None):
+        rc = _run_one_job(_job(retries=3), {}, "9.9.9", "testhost")
+
+    assert rc == 0
+    assert seen == [None, [b]], "first attempt runs everything, second only 'b'"
+
+
+def test_first_attempt_passes_none_so_the_job_list_is_used(reports):
+    seen = []
+
+    def fake_execute(job, logfile_path, targets=None):
+        seen.append(targets)
+        return 0, []
+
+    with patch("clouddump.__main__.execute_job", fake_execute):
+        _run_one_job(_job(), {}, "9.9.9", "testhost")
+
+    assert seen == [None]
+
+
+def test_crash_resets_to_the_full_target_list(reports):
+    """A crash says nothing about which targets got through, so retry them all."""
+    seen = []
+    calls = {"n": 0}
+
+    def fake_execute(job, logfile_path, targets=None):
+        seen.append(targets)
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return 1, [{"id": "b"}]
+        if calls["n"] == 2:
+            raise RuntimeError("boom")
+        return 0, []
+
+    with patch("clouddump.__main__.execute_job", fake_execute),          patch("clouddump.__main__.time.sleep", lambda _: None):
+        _run_one_job(_job(retries=3), {}, "9.9.9", "testhost")
+
+    assert seen == [None, [{"id": "b"}], None], "after a crash, back to the full list"
+
+
+def test_logfile_count_still_matches_attempts(reports):
+    """Retrying a subset must not change how many logs the report carries."""
+    responses = [(1, [{"id": "b"}]), (1, [{"id": "b"}]), (0, [])]
+    n = {"i": 0}
+
+    def fake_execute(job, logfile_path, targets=None):
+        r = responses[n["i"]]
+        n["i"] += 1
+        return r
+
+    with patch("clouddump.__main__.execute_job", fake_execute),          patch("clouddump.__main__.time.sleep", lambda _: None):
+        _run_one_job(_job(retries=3), {}, "9.9.9", "testhost")
+
+    assert len(reports[0]["logfile_paths"]) == 3
+
+
 # ── crashes ─────────────────────────────────────────────────────────────────
 
 
@@ -151,9 +223,9 @@ def test_logfiles_are_cleaned_up(reports):
 def test_current_job_is_set_during_and_cleared_after(reports):
     seen = []
 
-    def fake_execute(j, logfile_path):
+    def fake_execute(j, logfile_path, targets=None):
         seen.append(clouddump.current_job)
-        return 0
+        return 0, []
 
     with patch("clouddump.__main__.execute_job", fake_execute):
         _run_one_job(_job(), {}, "9.9.9", "testhost")
@@ -166,7 +238,7 @@ def test_current_job_cleared_even_when_reporting_raises():
     def boom(*a, **k):
         raise RuntimeError("smtp exploded")
 
-    with patch("clouddump.__main__.execute_job", lambda j, p: 0), \
+    with patch("clouddump.__main__.execute_job", lambda j, p, t=None: (0, [])), \
          patch("clouddump.__main__.send_job_report", boom):
         with pytest.raises(RuntimeError):
             _run_one_job(_job(), {}, "9.9.9", "testhost")
@@ -177,9 +249,9 @@ def test_current_job_cleared_even_when_reporting_raises():
 def test_deadline_is_set_per_attempt_and_cleared(reports):
     seen = []
 
-    def fake_execute(j, logfile_path):
+    def fake_execute(j, logfile_path, targets=None):
         seen.append(clouddump.job_deadline)
-        return 0
+        return 0, []
 
     with patch("clouddump.__main__.execute_job", fake_execute):
         _run_one_job(_job(timeout=1234), {}, "9.9.9", "testhost")

--- a/tests/test_runners.py
+++ b/tests/test_runners.py
@@ -1323,14 +1323,16 @@ class TestJobDispatch:
     def test_unknown_type_returns_1(self, _tmp_logfile):
         from clouddump.jobs import execute_job
 
-        rc = execute_job({"type": "nonexistent"}, _tmp_logfile)
+        rc, failed = execute_job({"type": "nonexistent"}, _tmp_logfile)
         assert rc == 1
+        assert failed == []
 
     def test_empty_targets_returns_1(self, _tmp_logfile):
         from clouddump.jobs import execute_job
 
-        rc = execute_job({"type": "azstorage", "blobstorages": []}, _tmp_logfile)
+        rc, failed = execute_job({"type": "azstorage", "blobstorages": []}, _tmp_logfile)
         assert rc == 1
+        assert failed == []
 
     def test_dispatches_to_azure(self, monkeypatch, tmp_path, _tmp_logfile):
         from clouddump.jobs import execute_job
@@ -1342,7 +1344,7 @@ class TestJobDispatch:
         })
 
         job = {"type": "azstorage", "blobstorages": [{"source": "https://b"}]}
-        rc = execute_job(job, _tmp_logfile)
+        rc, _ = execute_job(job, _tmp_logfile)
 
         assert rc == 0
         assert called_with == [{"source": "https://b"}]
@@ -1357,7 +1359,7 @@ class TestJobDispatch:
         })
 
         job = {"type": "github", "organizations": [{"name": "org1"}]}
-        rc = execute_job(job, _tmp_logfile)
+        rc, _ = execute_job(job, _tmp_logfile)
 
         assert rc == 0
         assert called_with == [{"name": "org1"}]
@@ -1379,10 +1381,60 @@ class TestJobDispatch:
         })
 
         job = {"type": "azstorage", "blobstorages": [{"id": "a"}, {"id": "b"}]}
-        rc = execute_job(job, _tmp_logfile)
+        rc, _ = execute_job(job, _tmp_logfile)
 
         assert rc == 1  # worst exit code
         assert called == ["a", "b"]  # both attempted
+
+    def test_failed_targets_are_returned(self, monkeypatch, _tmp_logfile):
+        """The retry loop needs to know which targets to run again."""
+        from clouddump.jobs import execute_job
+        from clouddump import jobs
+
+        a, b, c = {"id": "a"}, {"id": "b"}, {"id": "c"}
+        monkeypatch.setattr(jobs, "_RUNNERS", {
+            "azstorage": ("blobstorages", lambda t, lf: 0 if t["id"] == "b" else 1),
+        })
+
+        rc, failed = execute_job(
+            {"type": "azstorage", "blobstorages": [a, b, c]}, _tmp_logfile)
+
+        assert rc == 1
+        assert failed == [a, c], "the succeeding target must not be retried"
+
+    def test_targets_override_replaces_the_job_list(self, monkeypatch, _tmp_logfile):
+        """A retry runs only the subset it is given."""
+        from clouddump.jobs import execute_job
+        from clouddump import jobs
+
+        a, b, c = {"id": "a"}, {"id": "b"}, {"id": "c"}
+        seen = []
+        monkeypatch.setattr(jobs, "_RUNNERS", {
+            "azstorage": ("blobstorages", lambda t, lf: (seen.append(t["id"]), 0)[1]),
+        })
+
+        rc, failed = execute_job(
+            {"type": "azstorage", "blobstorages": [a, b, c]}, _tmp_logfile, targets=[c])
+
+        assert rc == 0
+        assert seen == ["c"]
+        assert failed == []
+
+    def test_empty_targets_override_is_not_treated_as_all(self, monkeypatch, _tmp_logfile):
+        """An empty subset must not silently fall back to running everything."""
+        from clouddump.jobs import execute_job
+        from clouddump import jobs
+
+        seen = []
+        monkeypatch.setattr(jobs, "_RUNNERS", {
+            "azstorage": ("blobstorages", lambda t, lf: (seen.append(t), 0)[1]),
+        })
+
+        rc, _ = execute_job(
+            {"type": "azstorage", "blobstorages": [{"id": "a"}]}, _tmp_logfile, targets=[])
+
+        assert seen == []
+        assert rc == 1
 
     def test_multiple_targets_all_succeed(self, monkeypatch, _tmp_logfile):
         from clouddump.jobs import execute_job
@@ -1393,5 +1445,5 @@ class TestJobDispatch:
         })
 
         job = {"type": "azstorage", "blobstorages": [{"id": "a"}, {"id": "b"}]}
-        rc = execute_job(job, _tmp_logfile)
+        rc, _ = execute_job(job, _tmp_logfile)
         assert rc == 0

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -472,6 +472,123 @@ def test_info_delimiter_non_string_rejected(caplog):
     assert any("exactly one character" in m for m in _delim_errors(caplog))
 
 
+def test_imap_duplicate_destination_rejected(caplog):
+    """mbsync keeps sync state in the Maildir; two accounts sharing one corrupt it."""
+    job = _job(type="imap", accounts=[
+        {"host": "h", "user": "a@x", "pass": "p", "destination": "/tmp/mail"},
+        {"host": "h", "user": "b@x", "pass": "p", "destination": "/tmp/mail"},
+    ])
+    with caplog.at_level(logging.ERROR, logger="clouddump"):
+        errors, _ = validate_jobs([job])
+    assert errors >= 1
+    assert any("share destination" in r.getMessage() for r in caplog.records)
+
+
+def test_imap_duplicate_destination_normalises_path(caplog):
+    """/tmp/mail and /tmp/./mail are the same directory."""
+    job = _job(type="imap", accounts=[
+        {"host": "h", "user": "a@x", "pass": "p", "destination": "/tmp/mail"},
+        {"host": "h", "user": "b@x", "pass": "p", "destination": "/tmp/./mail"},
+    ])
+    with caplog.at_level(logging.ERROR, logger="clouddump"):
+        validate_jobs([job])
+    assert any("share destination" in r.getMessage() for r in caplog.records)
+
+
+def test_imap_distinct_destinations_accepted(caplog):
+    job = _job(type="imap", accounts=[
+        {"host": "h", "user": "a@x", "pass": "p", "destination": "/tmp/mail/a"},
+        {"host": "h", "user": "b@x", "pass": "p", "destination": "/tmp/mail/b"},
+    ])
+    with caplog.at_level(logging.ERROR, logger="clouddump"):
+        validate_jobs([job])
+    assert not any("share destination" in r.getMessage() for r in caplog.records)
+
+
+# ── health state ────────────────────────────────────────────────────────────
+
+
+def test_update_job_metric_is_gated_by_the_lock():
+    """Deterministic: while the lock is held, a writer must not complete.
+
+    Racing the two threads empirically proved nothing — the writer finishes
+    before the reader's first deepcopy, so the test passed even with the lock
+    stubbed out. Asserting the gating directly is both faster and honest.
+    """
+    import threading as _th
+    from clouddump.health import _state, _lock, update_job_metric
+
+    started, finished = _th.Event(), _th.Event()
+
+    def writer():
+        started.set()
+        update_job_metric("locktest", "pgsql", "success", 1)
+        finished.set()
+
+    old = _state["jobs"].copy()
+    try:
+        with _lock:
+            t = _th.Thread(target=writer, daemon=True)
+            t.start()
+            assert started.wait(timeout=2), "writer thread never ran"
+            assert not finished.wait(timeout=0.3), "write completed while lock was held"
+        t.join(timeout=2)
+        assert finished.is_set(), "write did not complete after the lock was released"
+    finally:
+        _state["jobs"] = old
+
+
+def test_healthz_serves_valid_json_while_metrics_are_written():
+    """Smoke test: the real handler over a real socket, under concurrent writes.
+
+    Not a race detector — it passes with the lock stubbed out too, because the
+    writer usually finishes between requests. It is here to catch the handler
+    breaking outright (truncated body, wrong status, serialisation error). The
+    locking guarantee is covered deterministically by the test above.
+    """
+    import json as _json
+    import threading as _th
+    import urllib.request as _rq
+    from clouddump.health import _state, start_health_server, update_job_metric
+
+    server = start_health_server(port=0)  # ask the OS for a free port
+    assert server is not None
+    port = server.server_address[1]
+
+    done = _th.Event()
+
+    def writer():
+        try:
+            for i in range(3000):
+                update_job_metric(f"race-{i}", "pgsql", "success", i)
+        finally:
+            done.set()
+
+    old = _state["jobs"].copy()
+    try:
+        w = _th.Thread(target=writer, daemon=True)
+        w.start()
+        reads = 0
+        while not done.is_set() and reads < 40:
+            with _rq.urlopen(f"http://127.0.0.1:{port}/healthz", timeout=5) as r:
+                assert r.status == 200
+                _json.loads(r.read())  # must never be truncated or malformed
+            reads += 1
+        w.join(timeout=10)
+    finally:
+        _state["jobs"] = old
+
+
+def test_disabled_job_uses_a_field_the_json_formatter_keeps():
+    """'job_id' is not in _EXTRA_FIELDS, so it would be silently dropped."""
+    from clouddump import _EXTRA_FIELDS
+
+    assert "job" in _EXTRA_FIELDS
+    source = pathlib.Path(__file__).resolve().parent.parent / "clouddump" / "__main__.py"
+    text = source.read_text(encoding="utf-8")
+    assert 'extra={"job_id"' not in text
+
+
 # ── unknown config keys ─────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
Two commits, both from the codebase review. Kept together because the second
depends on the first touching the same file, and each is self-contained.

---

## 1. Three small correctness defects

### Two IMAP accounts could share a destination

mbsync keeps its sync state *inside* the Maildir, so two accounts pointed at one
directory overwrite each other's state on every run. With `delete_destination`
at its default of `true`, that resolves as deletion. Now a startup error, with
paths normalised so `/tmp/mail` and `/tmp/./mail` are recognised as the same
directory.

### `/healthz` was read without synchronisation

The main thread mutates `_state` while the HTTP thread serialises it. A scrape
landing mid-write could raise `dictionary changed size during iteration` and
return 500. Writers and the snapshot now share a lock, and the handler
serialises a deep copy taken under it.

### A log field was silently dropped

The disabled-job line passed `job_id`, which is not in `_EXTRA_FIELDS`, so the
JSON formatter discarded it — in `json` mode the line never said *which* job was
skipped. Now uses `job`.

`start_health_server` returns the `HTTPServer` (or `None`) so a test can bind
port 0 and discover the port.

**On the concurrency test:** the first version raced two threads and passed even
with the lock stubbed out — the writer finishes before the reader's first
deepcopy. Replaced with a deterministic assertion that a write cannot complete
while the lock is held, verified to fail against a `nullcontext` lock. The
end-to-end request test is kept as a handler smoke test and says so.

---

## 2. Extract `_run_one_job` so the orchestrator can be tested

`__main__.py` was 222 statements at **0% coverage**, and its densest part was the
nested job/attempt loop — retries, three-tier status, one log file per attempt,
the report email, cleanup — all inline in `main()`.

That is where a silent bug costs most. The report email is the only signal some
deployments have that a backup ran; one that also routes it to a dead-man switch
notices a *missing* email, not a *wrong* one.

Extracted verbatim into `_run_one_job(job, config, version, host) -> exit code`.
The caller keeps the tally and the run summary. Two behaviour changes, both
fixes:

- `current_job` is set and cleared via `try/finally`. Previously a raising
  `send_job_report` left the job id attached to every subsequent log line,
  including the next job's.
- `result` is initialised to `1`. If `retries` were ever 0 the attempt loop
  would not run and `result` would still hold the **previous job's** value —
  reporting one job's outcome under another's name. Validation forbids
  `retries < 1`, so this was latent, not live.

Removed four dead locals the extraction made obvious: `total_rx`/`total_tx` were
accumulated across attempts and never read, and both `divmod`-into-minutes pairs
were unused. Ruff's F841 misses all four — augmented assignment counts as a use,
and tuple unpacking is exempt.

### Coverage

| | before | after |
|---|---|---|
| `__main__.py` | **0%** | **43%** |
| `health.py` | 73% | 91% |
| project | 61% | **73%** |

The remaining `__main__` gap is `main()` itself — config loading, startup mail,
the sleep loop. It is a shell around this function and much harder to drive; not
attempted here.

Sixteen tests in a new `tests/test_main.py`, covering retry counts, the
Success/Warning/Failure boundaries, crashes as retryable failures,
exactly-one-report-per-job, log file cleanup, and that neither `current_job` nor
`job_deadline` leaks past a job.

---

## Verification

- `280 passed, 7 skipped` (was 258)
- `ruff check clouddump tests` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F3kdRiSB9DrpD2ynvvQ1m8

---

## 3. Retry only the targets that failed

A job may hold several targets. All are attempted even if earlier ones fail —
but a retry re-ran every one of them, including the targets that had just
succeeded. For mbsync or rsync that is a wasted rescan; for a pgsql server it is
a second full dump.

`execute_job` now returns `(exit_code, failed_targets)` and accepts a `targets`
override. The retry loop feeds the previous attempt's failures back in:

```
attempt 1:  [a, b, c]  ->  b fails
attempt 2:  [b]        ->  ok
```

A crash is treated differently: an exception says nothing about which targets got
through, so the pending list resets and the whole job is retried.

**The retry loop stays at job level.** That keeps one log file per attempt, and
therefore the same number of attachments on the report email. Moving retries
inside `execute_job` would have collapsed that to a single log per job — a
visible change to what lands in the operator's inbox, for no gain here.

An empty `targets` override means "nothing to run", not "run everything":
falling back to the full list on an empty subset would silently undo the point.

Seven more tests, including that the second attempt receives only the failed
subset, that a crash resets to the full list, and that the attachment count is
unchanged.

**Total: `287 passed, 7 skipped`, ruff clean.**
