### PR TITLE
fix: stop dropping "container" from json logs, and catch the whole class

### DIFF
--- a/clouddump/__init__.py
+++ b/clouddump/__init__.py
@@ -39,6 +39,7 @@ _EXTRA_FIELDS = frozenset({
     "host", "port", "database", "bytes", "database_count",
     "source", "destination",
     "account", "account_type",
+    "container",
 })
 
 _LEVEL_NAMES = {"WARNING": "warn", "CRITICAL": "crit"}

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -579,6 +579,29 @@ def test_healthz_serves_valid_json_while_metrics_are_written():
         _state["jobs"] = old
 
 
+def test_every_extra_key_survives_the_json_formatter():
+    """_JsonFormatter emits only keys in _EXTRA_FIELDS; the rest vanish silently.
+
+    Two bugs of this shape have shipped — `job_id` on the disabled-job line and
+    `container` in the Azure runner — both invisible because the text formatter
+    does not use the allowlist at all, so they only disappeared in json mode.
+    Scanning the source makes the class impossible to reintroduce quietly.
+    """
+    import re
+    from clouddump import _EXTRA_FIELDS
+
+    pkg = pathlib.Path(__file__).resolve().parent.parent / "clouddump"
+    offenders = {}
+    for src in sorted(pkg.glob("*.py")):
+        text = src.read_text(encoding="utf-8")
+        for literal in re.finditer(r"extra=\{([^}]*)\}", text, re.S):
+            for key in re.findall(r'"(\w+)"\s*:', literal.group(1)):
+                if key not in _EXTRA_FIELDS:
+                    offenders.setdefault(src.name, set()).add(key)
+
+    assert not offenders, f"extra= keys missing from _EXTRA_FIELDS: {offenders}"
+
+
 def test_disabled_job_uses_a_field_the_json_formatter_keeps():
     """'job_id' is not in _EXTRA_FIELDS, so it would be silently dropped."""
     from clouddump import _EXTRA_FIELDS


### PR DESCRIPTION
`_JsonFormatter` emits only the keys listed in `_EXTRA_FIELDS`. `job_azure`
passes `"container"` on three log lines and it is not in that set, so in `json`
mode the Azure sync lines never said which container they were about.

**This is the second one.** The disabled-job line had the same shape with
`job_id`, fixed earlier today. Both were invisible in testing because the *text*
formatter ignores the allowlist entirely — the fields only vanish once
`log_format` is `json`, which is exactly when something is parsing them.

## The fix

Adds `"container"`, plus a test that scans every `extra={...}` literal in the
package and asserts each key is in `_EXTRA_FIELDS`.

Verified the test fails with `"container"` removed again, so it catches the
class rather than this instance.

## How it was found

An audit for leftovers after the v2.1.0 work, prompted by the maintainer asking
whether anything was still lying around. The same sweep checked for unused
functions and unused module constants and found none.

Also verified on the running deployment: no warnings or errors across the whole
container lifetime (9294 debug lines, 71 info, zero above that), `/tmp` empty
inside the container, no stale `.dump.tmp` staging files on the share, and no
`gh-token-*` stranded in the backup tree from a v1 hard kill.

## Verification

- `288 passed, 7 skipped` (was 287)
- `ruff check clouddump tests` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F3kdRiSB9DrpD2ynvvQ1m8